### PR TITLE
Adds headers in all go files

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -1,3 +1,10 @@
+/*
+Apache Score
+Copyright 2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+*/
 package cmd
 
 import (

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -1,3 +1,10 @@
+/*
+Apache Score
+Copyright 2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+*/
 package cmd
 
 import (

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,3 +1,10 @@
+/*
+Apache Score
+Copyright 2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+*/
 package main
 
 import (

--- a/internal/compose/convert.go
+++ b/internal/compose/convert.go
@@ -1,3 +1,10 @@
+/*
+Apache Score
+Copyright 2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+*/
 package compose
 
 import (

--- a/internal/compose/convert_test.go
+++ b/internal/compose/convert_test.go
@@ -1,3 +1,10 @@
+/*
+Apache Score
+Copyright 2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+*/
 package compose
 
 import (

--- a/internal/compose/types.go
+++ b/internal/compose/types.go
@@ -1,3 +1,10 @@
+/*
+Apache Score
+Copyright 2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+*/
 package compose
 
 // ExternalVariables describes all external environment variables available for overriding.

--- a/internal/compose/write.go
+++ b/internal/compose/write.go
@@ -1,3 +1,10 @@
+/*
+Apache Score
+Copyright 2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+*/
 package compose
 
 import (

--- a/internal/compose/write_test.go
+++ b/internal/compose/write_test.go
@@ -1,3 +1,10 @@
+/*
+Apache Score
+Copyright 2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+*/
 package compose
 
 import (

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,10 @@
+/*
+Apache Score
+Copyright 2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+*/
 package version
 
 var (


### PR DESCRIPTION
Signed-off-by: rachfop <prachford@icloud.com>

Adds a [NOTICE FILE](https://www.apache.org/legal/src-headers.html#notice) to the top of every `.go` file.