### PR TITLE
Rename `workload` resource type into `service`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # ![Score](docs/images/logo.svg) Score overview
 
-Score aims to improve developer producticity and experience by reducing the risk of configurtaion inconsistencies between local and remote environments. It provides developer-centric workload specification (`score.yaml`) which captures a workloads runtime requirements in a platform-agnostic manner.
+Score aims to improve developer productivity and experience by reducing the risk of configuration inconsistencies between local and remote environments. It provides developer-centric workload specification (`score.yaml`) which captures a workloads runtime requirements in a platform-agnostic manner.
 
 The `score.yaml` specification file can be executed against a _Score Implementation CLI_, a conversion tool for application developers to generate environment specific configuration. In combination with environment specific parameters, the CLI tool can run your workload in the target environment by generating a platform-specific configuration file such as `docker-compose.yaml` or a Helm `values.yaml`. Learn more [here](https://github.com/score-spec/spec#-what-is-score).
 

--- a/e2e-tests/resources/outputs/example-03-dependencies-service-a-output.txt
+++ b/e2e-tests/resources/outputs/example-03-dependencies-service-a-output.txt
@@ -3,11 +3,6 @@ services:
     command:
       - -c
       - 'while true; do echo service-a: Hello $${FRIEND}! Connecting to $${CONNECTION_STRING}...; sleep 10; done'
-    depends_on:
-      db:
-        condition: service_started
-      service-b:
-        condition: service_started
     entrypoint:
       - /bin/sh
     environment:

--- a/examples/03-dependencies/compose.yaml
+++ b/examples/03-dependencies/compose.yaml
@@ -1,4 +1,10 @@
 services:
+  service-a:
+    depends_on:
+      db:
+        condition: service_started
+      service-b:
+        condition: service_started
   db:
     image: postgres:alpine
     restart: always

--- a/examples/03-dependencies/service-a.yaml
+++ b/examples/03-dependencies/service-a.yaml
@@ -33,4 +33,4 @@ resources:
       password:
         secret: true
   service-b:
-    type: workload
+    type: service

--- a/internal/compose/convert.go
+++ b/internal/compose/convert.go
@@ -31,13 +31,6 @@ func ConvertSpec(spec *score.WorkloadSpec) (*compose.Project, ExternalVariables,
 			env[key] = &envVarVal
 		}
 
-		var dependsOn = make(compose.DependsOnConfig, len(spec.Resources))
-		for name, res := range spec.Resources {
-			if res.Type != "environment" && res.Type != "volume" {
-				dependsOn[name] = compose.ServiceDependency{Condition: "service_started"}
-			}
-		}
-
 		var ports []compose.ServicePortConfig
 		if len(spec.Service.Ports) > 0 {
 			ports = []compose.ServicePortConfig{}
@@ -87,7 +80,6 @@ func ConvertSpec(spec *score.WorkloadSpec) (*compose.Project, ExternalVariables,
 			Entrypoint:  cSpec.Command,
 			Command:     cSpec.Args,
 			Environment: env,
-			DependsOn:   dependsOn,
 			Ports:       ports,
 			Volumes:     volumes,
 		}

--- a/internal/compose/convert_test.go
+++ b/internal/compose/convert_test.go
@@ -79,7 +79,6 @@ func TestScoreConvert(t *testing.T) {
 						Environment: compose.MappingWithEquals{
 							"CONNECTION_STRING": stringPtr("test connection string"),
 						},
-						DependsOn: make(compose.DependsOnConfig, 0),
 						Ports: []compose.ServicePortConfig{
 							{
 								Published: "80",
@@ -166,10 +165,6 @@ func TestScoreConvert(t *testing.T) {
 								Target:   "/mnt/data",
 								ReadOnly: true,
 							},
-						},
-						DependsOn: compose.DependsOnConfig{
-							"app-db": compose.ServiceDependency{Condition: "service_started"},
-							"dns":    compose.ServiceDependency{Condition: "service_started"},
 						},
 					},
 				},


### PR DESCRIPTION
Signed-off-by: Eugene Yarshevich <yarshevich@gmail.com>

#### Description

The latest Score spec renamed previously introduced `workload` resource type into `service` to support a proper level of abstraction.

We also remove service dependencies enforcement (`depends_on` section) from the produced `compose.yaml` file, as this configuration is environment-specific.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.
