### PR TITLE
Implemented a function to parse & print stacked errors

### DIFF
--- a/cmd/score-compose/main.go
+++ b/cmd/score-compose/main.go
@@ -15,8 +15,12 @@ import (
 )
 
 func main() {
-	if err := command.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+	status := command.ParseOpts()
+	if status == 0 {
+		if err := command.Execute(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 	}
+
 }

--- a/internal/command/parse.go
+++ b/internal/command/parse.go
@@ -1,0 +1,121 @@
+package command
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+type Usage struct {
+	Flags []string
+}
+
+var commandMap map[string]*Usage
+var invalidFlags []string
+
+func ParseOpts() int {
+
+	commandMap = map[string]*Usage{
+		"score-compose": {
+			Flags: []string{"h", "v", "help", "version"},
+		},
+		"run": {
+
+			Flags: []string{"h", "o", "f", "build", "env-file", "file", "help", "output", "overrides", "verbose"},
+		},
+		"help": {
+			Flags: []string{},
+		},
+		"version": {
+			Flags: []string{},
+		},
+	}
+
+	first_arg := os.Args[1]
+	checkIfValidScoreComposeFlags(first_arg, commandMap["score-compose"].Flags)
+	ok2 := checkIfValidScoreComposeCommand(first_arg, commandMap)
+	if ok2 {
+		checkForValidFlags(os.Args[1:], commandMap)
+	}
+
+	if len(invalidFlags) > 0 {
+
+		fmt.Printf("Error: Unknown command/flags: ")
+		for _, v := range invalidFlags {
+			value := string(v)
+			fmt.Printf("%v, ", value)
+		}
+		fmt.Printf("\nUse \"score-compose --help\" for more information.\n")
+		return -1
+	}
+	return 0
+}
+
+func checkForValidFlags(args []string, commandMap map[string]*Usage) {
+	validFlags := commandMap[args[0]].Flags
+	for _, v := range args {
+		value := string(v)
+		if strings.HasPrefix(value, "--") {
+			trim_arg := strings.TrimPrefix(value, "--")
+			if !contains(trim_arg, validFlags) {
+				if !contains(trim_arg, invalidFlags) {
+					invalidFlags = append(invalidFlags, trim_arg)
+
+				}
+
+			}
+		} else if strings.HasPrefix(value, "-") {
+			trim_arg := strings.TrimPrefix(value, "-")
+			for _, v := range trim_arg {
+				flag := string(v)
+				if !contains(flag, validFlags) {
+
+					if !contains(flag, invalidFlags) {
+						invalidFlags = append(invalidFlags, flag)
+					}
+
+				}
+			}
+
+		}
+
+	}
+
+}
+
+func checkIfValidScoreComposeFlags(arg string, Flags []string) {
+	if strings.HasPrefix(arg, "--") {
+		trim_arg := strings.TrimPrefix(arg, "--")
+		if !contains(trim_arg, Flags) {
+			if !contains(trim_arg, invalidFlags) {
+				invalidFlags = append(invalidFlags, trim_arg)
+			}
+		}
+	} else if strings.HasPrefix(arg, "-") {
+		trim_arg := strings.TrimPrefix(arg, "-")
+		for _, v := range trim_arg {
+			value := string(v)
+			if !contains(value, Flags) {
+				if !contains(value, invalidFlags) {
+					invalidFlags = append(invalidFlags, value)
+				}
+			}
+		}
+	}
+}
+
+func contains(v string, elements []string) bool {
+	for _, s := range elements {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+func checkIfValidScoreComposeCommand(arg string, commandMap map[string]*Usage) bool {
+	if _, ok := commandMap[arg]; ok {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Created a wrapper parser around `command.Execute()` which compares input commands/flags to valid ones. If true then only `command.Execute()` is executed otherwise program exits printing an error stack with invalid flags or commands and a `help` instruction.

#### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->
This is a solution for issue #7[Stack error messages in Score implementation CLIs](https://github.com/score-spec/spec/issues/7) 
<!--- If it fixes an open issue, please link to the issue here. -->



#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.
- [x] I have ran e2e-tests and all are passing.
[e2e-reports.zip](https://github.com/score-spec/score-compose/files/11310787/e2e-reports.zip)
