### PR TITLE
Properties overrides via command line parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ score-compose run -f /tmp/score.yaml -o /tmp/compose.yaml
 
 - `run` tells the CLI to translate the Score file to a Docker Compose file.
 - `-f` is the path to the Score file.
-- `--env` specifies the path to the output file.
+- `-o` specifies the path to the output file.
 
 If you're just getting started, follow [this guide](https://docs.score.dev/docs/get-started/score-compose-hello-world/) to run your first Hello World program with `score-compose`.
 

--- a/e2e-tests/resources/outputs/run --help-output.txt
+++ b/e2e-tests/resources/outputs/run --help-output.txt
@@ -10,6 +10,6 @@ Flags:
   -h, --help                   help for run
   -o, --output string          Output file
       --overrides string       Overrides SCORE file (default "./overrides.score.yaml")
-  -p, --property stringArray   Override selected property value
+  -p, --property stringArray   Overrides selected property value
       --skip-validation        DEPRECATED: Disables Score file schema validation
       --verbose                Enable diagnostic messages (written to STDERR)

--- a/e2e-tests/resources/outputs/run --help-output.txt
+++ b/e2e-tests/resources/outputs/run --help-output.txt
@@ -4,11 +4,12 @@ Usage:
   score-compose run [flags]
 
 Flags:
-      --build string       Replaces 'image' name with compose 'build' instruction
-      --env-file string    Location to store sample .env file
-  -f, --file string        Source SCORE file (default "./score.yaml")
-  -h, --help               help for run
-  -o, --output string      Output file
-      --overrides string   Overrides SCORE file (default "./overrides.score.yaml")
-      --skip-validation    DEPRECATED: Disables Score file schema validation
-      --verbose            Enable diagnostic messages (written to STDERR)
+      --build string           Replaces 'image' name with compose 'build' instruction
+      --env-file string        Location to store sample .env file
+  -f, --file string            Source SCORE file (default "./score.yaml")
+  -h, --help                   help for run
+  -o, --output string          Output file
+      --overrides string       Overrides SCORE file (default "./overrides.score.yaml")
+  -p, --property stringArray   Override selected property value
+      --skip-validation        DEPRECATED: Disables Score file schema validation
+      --verbose                Enable diagnostic messages (written to STDERR)

--- a/e2e-tests/resources/outputs/run --verbose-output.txt
+++ b/e2e-tests/resources/outputs/run --verbose-output.txt
@@ -4,13 +4,14 @@ Usage:
   score-compose run [flags]
 
 Flags:
-      --build string       Replaces 'image' name with compose 'build' instruction
-      --env-file string    Location to store sample .env file
-  -f, --file string        Source SCORE file (default "./score.yaml")
-  -h, --help               help for run
-  -o, --output string      Output file
-      --overrides string   Overrides SCORE file (default "./overrides.score.yaml")
-      --skip-validation    DEPRECATED: Disables Score file schema validation
-      --verbose            Enable diagnostic messages (written to STDERR)
+      --build string           Replaces 'image' name with compose 'build' instruction
+      --env-file string        Location to store sample .env file
+  -f, --file string            Source SCORE file (default "./score.yaml")
+  -h, --help                   help for run
+  -o, --output string          Output file
+      --overrides string       Overrides SCORE file (default "./overrides.score.yaml")
+  -p, --property stringArray   Override selected property value
+      --skip-validation        DEPRECATED: Disables Score file schema validation
+      --verbose                Enable diagnostic messages (written to STDERR)
 
 open ./score.yaml: no such file or directory

--- a/e2e-tests/resources/outputs/run --verbose-output.txt
+++ b/e2e-tests/resources/outputs/run --verbose-output.txt
@@ -10,7 +10,7 @@ Flags:
   -h, --help                   help for run
   -o, --output string          Output file
       --overrides string       Overrides SCORE file (default "./overrides.score.yaml")
-  -p, --property stringArray   Override selected property value
+  -p, --property stringArray   Overrides selected property value
       --skip-validation        DEPRECATED: Disables Score file schema validation
       --verbose                Enable diagnostic messages (written to STDERR)
 

--- a/e2e-tests/resources/outputs/run -f example-score.yaml -p containers.hello.image=hello:1.1-output.txt
+++ b/e2e-tests/resources/outputs/run -f example-score.yaml -p containers.hello.image=hello:1.1-output.txt
@@ -1,0 +1,8 @@
+services:
+  hello-world:
+    command:
+      - -c
+      - while true; do echo Hello World!; sleep 5; done
+    entrypoint:
+      - /bin/sh
+    image: hello:1.1

--- a/e2e-tests/resources/outputs/run-output.txt
+++ b/e2e-tests/resources/outputs/run-output.txt
@@ -3,13 +3,14 @@ Usage:
   score-compose run [flags]
 
 Flags:
-      --build string       Replaces 'image' name with compose 'build' instruction
-      --env-file string    Location to store sample .env file
-  -f, --file string        Source SCORE file (default "./score.yaml")
-  -h, --help               help for run
-  -o, --output string      Output file
-      --overrides string   Overrides SCORE file (default "./overrides.score.yaml")
-      --skip-validation    DEPRECATED: Disables Score file schema validation
-      --verbose            Enable diagnostic messages (written to STDERR)
+      --build string           Replaces 'image' name with compose 'build' instruction
+      --env-file string        Location to store sample .env file
+  -f, --file string            Source SCORE file (default "./score.yaml")
+  -h, --help                   help for run
+  -o, --output string          Output file
+      --overrides string       Overrides SCORE file (default "./overrides.score.yaml")
+  -p, --property stringArray   Override selected property value
+      --skip-validation        DEPRECATED: Disables Score file schema validation
+      --verbose                Enable diagnostic messages (written to STDERR)
 
 open ./score.yaml: no such file or directory

--- a/e2e-tests/resources/outputs/run-output.txt
+++ b/e2e-tests/resources/outputs/run-output.txt
@@ -9,7 +9,7 @@ Flags:
   -h, --help                   help for run
   -o, --output string          Output file
       --overrides string       Overrides SCORE file (default "./overrides.score.yaml")
-  -p, --property stringArray   Override selected property value
+  -p, --property stringArray   Overrides selected property value
       --skip-validation        DEPRECATED: Disables Score file schema validation
       --verbose                Enable diagnostic messages (written to STDERR)
 

--- a/e2e-tests/score-compose-cli.robot
+++ b/e2e-tests/score-compose-cli.robot
@@ -95,6 +95,9 @@ Verify score-compose run
     Execute score-compose with run -f ${RESOURCES_DIR}example-score.yaml --overrides ${RESOURCES_DIR}overrides.yaml
     Exit code is 0
     Vaildate output
+    Execute score-compose with run -f ${RESOURCES_DIR}example-score.yaml -p containers.hello.image=hello:1.1
+    Exit code is 0
+    Vaildate output
 
 Verify score-compose run (error cases)
     Execute score-compose with run

--- a/e2e-tests/utility/generate-expected-outputs.py
+++ b/e2e-tests/utility/generate-expected-outputs.py
@@ -29,6 +29,7 @@ arglist = [
     "run -f example-score.yaml",
     "run -f example-score.yaml --build test",
     "run -f example-score.yaml --overrides overrides.yaml",
+    "run -f example-score.yaml -p containers.hello.image=hello:1.1",
     "run --verbose",
 ]
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/score-spec/score-go v0.0.0-20230601114155-58fa99cb56f8
 	github.com/spf13/cobra v1.6.0
 	github.com/stretchr/testify v1.8.0
+	github.com/tidwall/sjson v1.2.5
 	github.com/xeipuuv/gojsonschema v1.2.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -21,6 +22,9 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/tidwall/gjson v1.14.4 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,16 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
+github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -55,7 +55,7 @@ func init() {
 	runCmd.Flags().StringVar(&envFile, "env-file", "", "Location to store sample .env file")
 	runCmd.Flags().StringVar(&buildCtx, "build", "", "Replaces 'image' name with compose 'build' instruction")
 
-	runCmd.Flags().StringArrayVarP(&overrideParams, "property", "p", nil, "Override selected property value")
+	runCmd.Flags().StringArrayVarP(&overrideParams, "property", "p", nil, "Overrides selected property value")
 
 	runCmd.Flags().BoolVar(&skipValidation, "skip-validation", false, "DEPRECATED: Disables Score file schema validation")
 	runCmd.Flags().BoolVar(&verbose, "verbose", false, "Enable diagnostic messages (written to STDERR)")

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -8,16 +8,19 @@ The Apache Software Foundation (http://www.apache.org/).
 package command
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/compose-spec/compose-go/types"
 	"github.com/imdario/mergo"
 	"github.com/spf13/cobra"
+	"github.com/tidwall/sjson"
 	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/score-spec/score-compose/internal/compose"
@@ -39,6 +42,8 @@ var (
 	envFile       string
 	buildCtx      string
 
+	overrideParams []string
+
 	skipValidation bool
 	verbose        bool
 )
@@ -49,6 +54,8 @@ func init() {
 	runCmd.Flags().StringVarP(&outFile, "output", "o", "", "Output file")
 	runCmd.Flags().StringVar(&envFile, "env-file", "", "Location to store sample .env file")
 	runCmd.Flags().StringVar(&buildCtx, "build", "", "Replaces 'image' name with compose 'build' instruction")
+
+	runCmd.Flags().StringArrayVarP(&overrideParams, "property", "p", nil, "Override selected property value")
 
 	runCmd.Flags().BoolVar(&skipValidation, "skip-validation", false, "DEPRECATED: Disables Score file schema validation")
 	runCmd.Flags().BoolVar(&verbose, "verbose", false, "Enable diagnostic messages (written to STDERR)")
@@ -85,7 +92,7 @@ func run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Apply overrides (optional)
+	// Apply overrides from file (optional)
 	//
 	if overridesFile != "" {
 		log.Printf("Checking '%s'...\n", overridesFile)
@@ -102,6 +109,34 @@ func run(cmd *cobra.Command, args []string) error {
 			}
 		} else if !os.IsNotExist(err) || overridesFile != overridesFileDefault {
 			return err
+		}
+	}
+
+	// Apply overrides from command line (optional)
+	//
+	for _, pstr := range overrideParams {
+		log.Print("Applying SCORE properties overrides...\n")
+
+		jsonBytes, err := json.Marshal(srcMap)
+		if err != nil {
+			return fmt.Errorf("marshalling score spec: %w", err)
+		}
+
+		pmap := strings.SplitN(pstr, "=", 2)
+		if len(pmap) <= 1 {
+			log.Printf("removing '%s'", pmap[0])
+			if jsonBytes, err = sjson.DeleteBytes(jsonBytes, pmap[0]); err != nil {
+				return fmt.Errorf("removing '%s': %w", pmap[0], err)
+			}
+		} else {
+			log.Printf("overriding '%s' = '%s'", pmap[0], pmap[1])
+			if jsonBytes, err = sjson.SetBytes(jsonBytes, pmap[0], pmap[1]); err != nil {
+				return fmt.Errorf("overriding '%s': %w", pmap[0], err)
+			}
+		}
+
+		if err = json.Unmarshal(jsonBytes, &srcMap); err != nil {
+			return fmt.Errorf("unmarshalling score spec: %w", err)
 		}
 	}
 


### PR DESCRIPTION
Properties overrides via command line parameters

#### Description
Allows users to override individual properties via command line arguments.

For example:
```
# Overrides the image for a container
score-compose run -f example-score.yaml -p containers.hello.image=hello:1.1

# Removes the property completely
score-compose run -f example-score.yaml -p metadata.some-property=
```

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.
