### PR TITLE
Support numbers and bool values with command line overrides

### DIFF
--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -24,6 +24,7 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/score-spec/score-compose/internal/compose"
+	"github.com/score-spec/score-compose/internal/utils"
 
 	loader "github.com/score-spec/score-go/loader"
 	schema "github.com/score-spec/score-go/schema"
@@ -124,14 +125,17 @@ func run(cmd *cobra.Command, args []string) error {
 
 		pmap := strings.SplitN(pstr, "=", 2)
 		if len(pmap) <= 1 {
-			log.Printf("removing '%s'", pmap[0])
-			if jsonBytes, err = sjson.DeleteBytes(jsonBytes, pmap[0]); err != nil {
-				return fmt.Errorf("removing '%s': %w", pmap[0], err)
+			var path = pmap[0]
+			log.Printf("removing '%s'", path)
+			if jsonBytes, err = sjson.DeleteBytes(jsonBytes, path); err != nil {
+				return fmt.Errorf("removing '%s': %w", path, err)
 			}
 		} else {
-			log.Printf("overriding '%s' = '%s'", pmap[0], pmap[1])
-			if jsonBytes, err = sjson.SetBytes(jsonBytes, pmap[0], pmap[1]); err != nil {
-				return fmt.Errorf("overriding '%s': %w", pmap[0], err)
+			var path = pmap[0]
+			var val = utils.TryParseJsonValue(pmap[1])
+			log.Printf("overriding '%s' = '%s'", path, val)
+			if jsonBytes, err = sjson.SetBytes(jsonBytes, path, val); err != nil {
+				return fmt.Errorf("overriding '%s': %w", path, err)
 			}
 		}
 

--- a/internal/utils/parse.go
+++ b/internal/utils/parse.go
@@ -1,0 +1,43 @@
+/*
+Apache Score
+Copyright 2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+*/
+package utils
+
+import (
+	"strconv"
+	"strings"
+)
+
+// TryParseJsonValue attempts to convert an input string into a simple JSON value (string, number, boolean, or null).
+//
+// Complex values (arrays and objects) are not supported and treated as strings.
+// Quoted values are always treated as strings.
+//
+// Conversion rules:
+//
+//	null    -> nil
+//	123     -> float64
+//	"123"   -> string
+//	false   -> boolean
+//	"false" -> string
+//	abc     -> string
+//	"abc"   -> string
+func TryParseJsonValue(str string) interface{} {
+	if str == "null" {
+		return nil
+	} else if strings.HasPrefix(str, "\"") {
+		return strings.Trim(str, "\"")
+	}
+
+	if val, err := strconv.ParseFloat(str, 64); err == nil {
+		return val
+	} else if val, err := strconv.ParseBool(str); err == nil {
+		return val
+	}
+
+	return str
+}

--- a/internal/utils/parse_test.go
+++ b/internal/utils/parse_test.go
@@ -1,0 +1,37 @@
+/*
+Apache Score
+Copyright 2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+*/
+package utils
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+)
+
+func TestTryParseJsonValue(t *testing.T) {
+	assert.Equal(t, "", TryParseJsonValue(""))
+	assert.Equal(t, "", TryParseJsonValue("\"\""))
+
+	assert.Equal(t, nil, TryParseJsonValue("null"))
+	assert.Equal(t, "null", TryParseJsonValue("\"null\""))
+
+	assert.Equal(t, float64(123), TryParseJsonValue("123"))
+	assert.Equal(t, float64(-123.23), TryParseJsonValue("-123.23"))
+	assert.Equal(t, "123", TryParseJsonValue("\"123\""))
+	assert.Equal(t, "123 123", TryParseJsonValue("123 123"))
+
+	assert.Equal(t, true, TryParseJsonValue("true"))
+	assert.Equal(t, false, TryParseJsonValue("false"))
+	assert.Equal(t, "false", TryParseJsonValue("\"false\""))
+	assert.Equal(t, "true 23", TryParseJsonValue("true 23"))
+
+	assert.Equal(t, "abc", TryParseJsonValue("abc"))
+	assert.Equal(t, "abc", TryParseJsonValue("\"abc\""))
+	assert.Equal(t, "{\"key\": \"value\"}", TryParseJsonValue("{\"key\": \"value\"}"))
+	assert.Equal(t, "[1, 2, 3]", TryParseJsonValue("[1, 2, 3]"))
+}


### PR DESCRIPTION
Support numbers and bool values with command line overrides.

This change complements https://github.com/score-spec/score-compose/pull/35.


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.
