### PR TITLE
Fix: Do not substitute strings without brackets

### DIFF
--- a/internal/compose/templates_test.go
+++ b/internal/compose/templates_test.go
@@ -71,6 +71,7 @@ func TestSubstitute(t *testing.T) {
 
 	assert.Equal(t, "", ctx.Substitute(""))
 	assert.Equal(t, "abc", ctx.Substitute("abc"))
+	assert.Equal(t, "$abc", ctx.Substitute("$abc"))
 	assert.Equal(t, "abc $ abc", ctx.Substitute("abc $$ abc"))
 	assert.Equal(t, "${abc}", ctx.Substitute("$${abc}"))
 


### PR DESCRIPTION
Fix to pass through strings without brackets, e.g. `$abc` -> `$abc`.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.
