### PR TITLE
fix: update score-go library to fix metadata fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/compose-spec/compose-go v1.6.0
 	github.com/imdario/mergo v0.3.13
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/score-spec/score-go v1.0.2
+	github.com/score-spec/score-go v1.0.3
 	github.com/spf13/cobra v1.6.0
 	github.com/stretchr/testify v1.8.0
 	github.com/tidwall/sjson v1.2.5

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
-github.com/score-spec/score-go v1.0.2 h1:xuzAIK9vNr1Vi4YcsZIdsmLEkfI826pMg5R+vysdf6A=
-github.com/score-spec/score-go v1.0.2/go.mod h1:nt6TOq2Ld9SiH3Fd9NF8tiJ9L7S17OE3FNgCrSet5GQ=
+github.com/score-spec/score-go v1.0.3 h1:wNbGcY5Ms4FRfr/qtRVP7fojU9HaDPYkTnzNu0N/ga8=
+github.com/score-spec/score-go v1.0.3/go.mod h1:nt6TOq2Ld9SiH3Fd9NF8tiJ9L7S17OE3FNgCrSet5GQ=
 github.com/spf13/cobra v1.6.0 h1:42a0n6jwCot1pUmomAp4T7DeMD+20LFv4Q54pxLf2LI=
 github.com/spf13/cobra v1.6.0/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/internal/compose/convert.go
+++ b/internal/compose/convert.go
@@ -23,6 +23,11 @@ func ConvertSpec(spec *score.Workload) (*compose.Project, ExternalVariables, err
 		return nil, nil, fmt.Errorf("preparing context: %w", err)
 	}
 
+	workloadName, ok := spec.Metadata["name"].(string)
+	if !ok || len(workloadName) == 0 {
+		return nil, nil, errors.New("workload metadata is missing a name")
+	}
+
 	if len(spec.Containers) == 0 {
 		return nil, nil, errors.New("workload does not have any containers to convert into a compose service")
 	}
@@ -92,7 +97,7 @@ func ConvertSpec(spec *score.Workload) (*compose.Project, ExternalVariables, err
 		// END (NOTE)
 
 		var svc = compose.ServiceConfig{
-			Name:        spec.Metadata.Name + "-" + containerName,
+			Name:        workloadName + "-" + containerName,
 			Image:       cSpec.Image,
 			Entrypoint:  cSpec.Command,
 			Command:     cSpec.Args,

--- a/internal/compose/convert_test.go
+++ b/internal/compose/convert_test.go
@@ -34,7 +34,7 @@ func TestScoreConvert(t *testing.T) {
 			Name: "Should convert SCORE to docker-compose spec",
 			Source: &score.Workload{
 				Metadata: score.WorkloadMetadata{
-					Name: "test",
+					"name": "test",
 				},
 				Service: &score.WorkloadService{
 					Ports: score.WorkloadServicePorts{
@@ -99,7 +99,7 @@ func TestScoreConvert(t *testing.T) {
 			Name: "Should convert all resources references",
 			Source: &score.Workload{
 				Metadata: score.WorkloadMetadata{
-					Name: "test",
+					"name": "test",
 				},
 				Containers: score.WorkloadContainers{
 					"backend": score.Container{
@@ -167,7 +167,7 @@ func TestScoreConvert(t *testing.T) {
 			Name: "Should support multiple containers",
 			Source: &score.Workload{
 				Metadata: score.WorkloadMetadata{
-					Name: "test",
+					"name": "test",
 				},
 				Containers: score.WorkloadContainers{
 					"frontend": score.Container{
@@ -222,7 +222,7 @@ func TestScoreConvert(t *testing.T) {
 			Name: "Should report an error for volumes with sub path (not supported)",
 			Source: &score.Workload{
 				Metadata: score.WorkloadMetadata{
-					Name: "test",
+					"name": "test",
 				},
 				Containers: score.WorkloadContainers{
 					"backend": score.Container{

--- a/internal/compose/templates_test.go
+++ b/internal/compose/templates_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestMapVar(t *testing.T) {
 	var meta = score.WorkloadMetadata{
-		Name: "test-name",
+		"name": "test-name",
 	}
 
 	var resources = score.WorkloadResources{
@@ -52,7 +52,7 @@ func TestMapVar(t *testing.T) {
 
 func TestSubstitute(t *testing.T) {
 	var meta = score.WorkloadMetadata{
-		Name: "test-name",
+		"name": "test-name",
 	}
 
 	var resources = score.WorkloadResources{


### PR DESCRIPTION
This PR brings in a fix from the score-go library: https://github.com/score-spec/score-go/pull/25

This means we still have access to extended metadata fields in the workload spec, and workload resource. 

The impact of this is low in this library, because other metadata fields were being ignored and not used anyway, however this keeps us up to date tracking the head of the library for any future changes.

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] I've signed off with an email address that matches the commit author.
