### PR TITLE
feat: upgraded score-go to 1.1.0 and call upgrade function

### DIFF
--- a/e2e-tests/resources/outputs/example-04-extras-output.txt
+++ b/e2e-tests/resources/outputs/example-04-extras-output.txt
@@ -8,3 +8,4 @@ services:
       - type: volume
         source: data
         target: /usr/share/nginx/html
+        read_only: true

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/compose-spec/compose-go v1.6.0
 	github.com/imdario/mergo v0.3.13
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/score-spec/score-go v1.0.3
+	github.com/score-spec/score-go v1.1.0
 	github.com/spf13/cobra v1.6.0
 	github.com/stretchr/testify v1.8.0
 	github.com/tidwall/sjson v1.2.5

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
-github.com/score-spec/score-go v1.0.3 h1:wNbGcY5Ms4FRfr/qtRVP7fojU9HaDPYkTnzNu0N/ga8=
-github.com/score-spec/score-go v1.0.3/go.mod h1:nt6TOq2Ld9SiH3Fd9NF8tiJ9L7S17OE3FNgCrSet5GQ=
+github.com/score-spec/score-go v1.1.0 h1:63WM1u93NtGgMuPtVZ/UBfzg/BpYuY8sBquaL0BkrXU=
+github.com/score-spec/score-go v1.1.0/go.mod h1:nt6TOq2Ld9SiH3Fd9NF8tiJ9L7S17OE3FNgCrSet5GQ=
 github.com/spf13/cobra v1.6.0 h1:42a0n6jwCot1pUmomAp4T7DeMD+20LFv4Q54pxLf2LI=
 github.com/spf13/cobra v1.6.0/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -151,6 +151,15 @@ func run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Apply upgrades to fix backports or backward incompatible things
+	if changes, err := schema.ApplyCommonUpgradeTransforms(srcMap); err != nil {
+		return fmt.Errorf("failed to upgrade spec: %w", err)
+	} else if len(changes) > 0 {
+		for _, change := range changes {
+			log.Printf("Applying upgrade to specification: %s\n", change)
+		}
+	}
+
 	// Validate SCORE spec
 	//
 	if !skipValidation {

--- a/internal/compose/convert.go
+++ b/internal/compose/convert.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	compose "github.com/compose-spec/compose-go/types"
 	score "github.com/score-spec/score-go/types"
@@ -43,10 +44,14 @@ func ConvertSpec(spec *score.Workload) (*compose.Project, ExternalVariables, err
 		ports = []compose.ServicePortConfig{}
 		for _, pSpec := range spec.Service.Ports {
 			var pubPort = fmt.Sprintf("%v", pSpec.Port)
+			var protocol string
+			if pSpec.Protocol != nil {
+				protocol = strings.ToLower(string(*pSpec.Protocol))
+			}
 			ports = append(ports, compose.ServicePortConfig{
 				Published: pubPort,
 				Target:    uint32(DerefOr(pSpec.TargetPort, pSpec.Port)),
-				Protocol:  DerefOr(pSpec.Protocol, ""),
+				Protocol:  protocol,
 			})
 		}
 	}

--- a/internal/compose/convert_test.go
+++ b/internal/compose/convert_test.go
@@ -44,7 +44,7 @@ func TestScoreConvert(t *testing.T) {
 						},
 						"admin": score.ServicePort{
 							Port:     8080,
-							Protocol: Ref("udp"),
+							Protocol: Ref(score.ServicePortProtocolUDP),
 						},
 					},
 				},


### PR DESCRIPTION
This upgrades score-compose to score-go 1.1.0 (https://github.com/score-spec/score-go/releases/tag/v1.1.0). The only real change affecting score compose is some fixes to the service protocol strings and the fixed naming of volume read only. The old form of read_only will continue to work due to the call to `ApplyCommonUpgradeTransforms`. 

The example files and tutorials have been updated in score docs.

We also start adding CLI unit tests that are hopefully more easy to run than the robot e2e tests.