### PR TITLE
feat: support --image and --build on score-compose generate 

### DIFF
--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -176,7 +176,7 @@ func run(cmd *cobra.Command, args []string) error {
 	// Build a fake score-compose init state. We don't actually need to store or persist this because we're not doing
 	// anything iterative or stateful.
 	state := &project.State{MountsDirectory: "/dev/null"}
-	state, err = state.WithWorkload(&spec, &scoreFile)
+	state, err = state.WithWorkload(&spec, &scoreFile, nil)
 	if err != nil {
 		return fmt.Errorf("failed to add score file to state: %w", err)
 	}
@@ -207,7 +207,7 @@ func run(cmd *cobra.Command, args []string) error {
 	// Build docker-compose configuration
 	//
 	slog.Info("Building docker-compose configuration")
-	proj, err := compose.ConvertSpec(&spec, workloadResourceOutputs)
+	proj, err := compose.ConvertSpec(&spec, nil, workloadResourceOutputs)
 	if err != nil {
 		return fmt.Errorf("building docker-compose configuration: %w", err)
 	}

--- a/internal/compose/convert.go
+++ b/internal/compose/convert.go
@@ -22,7 +22,7 @@ import (
 )
 
 // ConvertSpec converts SCORE specification into docker-compose configuration.
-func ConvertSpec(spec *score.Workload, resources map[string]project.OutputLookupFunc) (*compose.Project, error) {
+func ConvertSpec(spec *score.Workload, containerBuildConfigs map[string]compose.BuildConfig, resources map[string]project.OutputLookupFunc) (*compose.Project, error) {
 	workloadName, ok := spec.Metadata["name"].(string)
 	if !ok || len(workloadName) == 0 {
 		return nil, errors.New("workload metadata is missing a name")
@@ -158,6 +158,12 @@ func ConvertSpec(spec *score.Workload, resources map[string]project.OutputLookup
 			Environment: env,
 			Ports:       ports,
 			Volumes:     volumes,
+		}
+
+		if bc, ok := containerBuildConfigs[containerName]; ok {
+			slog.Info(fmt.Sprintf("containers.%s: overriding container build config to context=%s", containerName, bc.Context))
+			svc.Build = &bc
+			svc.Image = ""
 		}
 
 		// if we are not the "first" service, then inherit the network from the first service

--- a/internal/compose/convert_test.go
+++ b/internal/compose/convert_test.go
@@ -288,7 +288,7 @@ func TestScoreConvert(t *testing.T) {
 			po, _ = evt.GenerateSubProvisioner("some-dns", "").Provision(nil, nil)
 			resourceOutputs["some-dns"] = po.OutputLookupFunc
 
-			proj, err := ConvertSpec(tt.Source, resourceOutputs)
+			proj, err := ConvertSpec(tt.Source, nil, resourceOutputs)
 
 			if tt.Error != nil {
 				// On Error

--- a/internal/project/state_test.go
+++ b/internal/project/state_test.go
@@ -19,7 +19,7 @@ func mustLoadWorkload(t *testing.T, spec string) *score.Workload {
 func mustAddWorkload(t *testing.T, s *State, spec string) *State {
 	t.Helper()
 	w := mustLoadWorkload(t, spec)
-	n, err := s.WithWorkload(w, nil)
+	n, err := s.WithWorkload(w, nil, nil)
 	require.NoError(t, err)
 	return n
 }
@@ -37,7 +37,7 @@ containers:
 resources:
   foo:
     type: thing
-`), nil)
+`), nil, nil)
 		require.NoError(t, err)
 		assert.Len(t, start.Workloads, 0)
 		assert.Len(t, next.Workloads, 1)
@@ -59,7 +59,7 @@ containers:
 resources:
   foo:
     type: thing
-`), nil)
+`), nil, nil)
 		require.NoError(t, err)
 		next2, err := next1.WithWorkload(mustLoadWorkload(t, `
 metadata:
@@ -67,7 +67,7 @@ metadata:
 containers:
   hello-world:
     image: hi
-`), nil)
+`), nil, nil)
 		require.NoError(t, err)
 
 		assert.Len(t, start.Workloads, 0)


### PR DESCRIPTION
Depends on https://github.com/score-spec/score-compose/pull/65

This PR adds the `--image` and `--build` flags to score-compose `generate`.

The `--image` flag works like other score implementations, and provides a default image for any containers that have `image: .`. If you want to override a container which already has an image, use `--override-property` instead.

The `--build` flag accepts either a plain directory string as a build context per container: `--build hello-world=./subdir`, or a more complex json structure which supports additional context things like args and custom docker files: `--build 'hello-world={"dockerfile":"Dockerfile.example"}'`.

Both `--image` and `--build` are stored in the context so that any future generate calls continue to use them unless the workload is overidden again.

This is tested with unit tests and all decoding is strict with compose-specified models.