### PR TITLE
feat: support dependency order between resource services and workload services

### DIFF
--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -152,6 +152,8 @@
       - |
         cd /db-scripts
         ls db-*.sql | xargs cat | psql "postgresql://postgres:$${POSTGRES_PASSWORD}@{{ dig .Init.sk "instanceServiceName" "" .Shared }}:5432/postgres"
+      labels:
+        dev.score.compose.labels.is-init-container: "true"
       depends_on:
         {{ dig .Init.sk "instanceServiceName" "" .Shared }}:
           condition: service_healthy

--- a/internal/command/generate_test.go
+++ b/internal/command/generate_test.go
@@ -261,3 +261,93 @@ resources:
 		assert.NoError(t, cmd.Run())
 	})
 }
+
+func TestInitAndGenerate_with_depends_on(t *testing.T) {
+	td := changeToTempDir(t)
+	stdout, _, err := executeAndResetCommand(context.Background(), rootCmd, []string{"init"})
+	assert.NoError(t, err)
+	assert.Equal(t, "", stdout)
+
+	assert.NoError(t, os.WriteFile("score.yaml", []byte(`
+apiVersion: score.dev/v1b1
+metadata:
+  name: example
+containers:
+  example:
+    image: foo
+resources:
+  thing:
+    type: thing
+`), 0644))
+
+	assert.NoError(t, os.WriteFile(".score-compose/00-custom.provisioners.yaml", []byte(`
+- uri: template://blah
+  type: thing
+  services: |
+    init_service:
+      image: thing
+      labels:
+        dev.score.compose.labels.is-init-container: "true"
+    generic_service:
+      image: other
+    service_with_healthcheck:
+      image: something
+      healthcheck:
+        test: ["CMD", "boo"]
+`), 0644))
+	// generate
+	stdout, _, err = executeAndResetCommand(context.Background(), rootCmd, []string{"generate", "score.yaml"})
+	assert.NoError(t, err)
+	assert.Equal(t, "", stdout)
+	raw, err := os.ReadFile(filepath.Join(td, "compose.yaml"))
+	assert.NoError(t, err)
+	assert.Equal(t, `name: "001"
+services:
+    example-example:
+        depends_on:
+            wait-for-resources:
+                condition: service_started
+                required: false
+        image: foo
+    generic_service:
+        image: other
+    init_service:
+        image: thing
+        labels:
+            dev.score.compose.labels.is-init-container: "true"
+    service_with_healthcheck:
+        healthcheck:
+            test:
+                - CMD
+                - boo
+        image: something
+    wait-for-resources:
+        command:
+            - echo
+        depends_on:
+            generic_service:
+                condition: service_started
+                required: true
+            init_service:
+                condition: service_completed_successfully
+                required: true
+            service_with_healthcheck:
+                condition: service_healthy
+                required: true
+        image: alpine
+`, string(raw))
+
+	t.Run("validate compose spec", func(t *testing.T) {
+		if os.Getenv("NO_DOCKER") != "" {
+			t.Skip("NO_DOCKER is set")
+			return
+		}
+		dockerCmd, err := exec.LookPath("docker")
+		require.NoError(t, err)
+		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "convert", "--quiet", "--dry-run")
+		cmd.Dir = td
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		assert.NoError(t, cmd.Run())
+	})
+}


### PR DESCRIPTION
When resource provisioners create services that take some time to start up or have init containers that _must_ complete before the workload services start, we need to determine a start up order.

This PR adds a new service called `wait_for_resources` which is used as a coordination point. This is only added when resource services are provisioned and it gets a dependency added for each one. When present, the workload services will now wait for this service to run before they may start.

You can see this affect in the unit test added in generate_test.go.

The ready condition is tuned based on what we can detect about the container. Since we cannot always distinguish services that are init containers, we have an opt-in / best-effort label which can be added in provisioners to indicate that we must wait for the service to actually finish.

