### PR TITLE
feat: added support for container files

### DIFF
--- a/internal/command/generate.go
+++ b/internal/command/generate.go
@@ -213,7 +213,7 @@ arguments.
 			}
 
 			slog.Info(fmt.Sprintf("Converting workload '%s' to Docker compose", workloadName))
-			converted, err := compose.ConvertSpec(&workloadState.Spec, workloadState.BuildConfigs, outputFunctions)
+			converted, err := compose.ConvertSpec(currentState, &workloadState.Spec, workloadState.BuildConfigs, outputFunctions)
 			if err != nil {
 				return fmt.Errorf("failed to convert workload '%s' to Docker compose: %w", workloadName, err)
 			}

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -207,7 +207,7 @@ func run(cmd *cobra.Command, args []string) error {
 	// Build docker-compose configuration
 	//
 	slog.Info("Building docker-compose configuration")
-	proj, err := compose.ConvertSpec(&spec, nil, workloadResourceOutputs)
+	proj, err := compose.ConvertSpec(state, &spec, nil, workloadResourceOutputs)
 	if err != nil {
 		return fmt.Errorf("building docker-compose configuration: %w", err)
 	}

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -264,7 +264,7 @@ containers:
       content: bananas
 `), 0600))
 	stdout, stderr, err := executeAndResetCommand(context.Background(), rootCmd, []string{"run", "--file", filepath.Join(td, "score.yaml"), "--output", filepath.Join(td, "compose.yaml")})
-	assert.EqualError(t, err, "building docker-compose configuration: containers.container-one1.files: not supported")
+	assert.EqualError(t, err, "building docker-compose configuration: files are not supported")
 	assert.Equal(t, "", stdout)
 	assert.NotEqual(t, "", strings.TrimSpace(stderr))
 }


### PR DESCRIPTION
Until now, score-compose has not supported container files. This is a big lack of a fairly core feature of the score specification. Now we have it!

Given a score file like:

```
apiVersion: score.dev/v1b1

metadata:
  name: example

service:
  ports:
    www:
      port: 8080
      targetPort: 80

containers:
  example:
    image: nginx:latest
    files:
      - source: ./1084-536x354-grayscale.jpg
        noExpand: true
        target: /usr/share/nginx/html/1084-536x354-grayscale.jpg
      - target: /usr/share/nginx/html/index.html
        content: |
          <html>
          <h1>Hello! I am workload '${metadata.name}'</h1>
          <img src="1084-536x354-grayscale.jpg" />
          </html>
```

We now get a useful nginx server out of it:

![image](https://github.com/score-spec/score-compose/assets/1651305/4033c294-4dec-4bbe-a8cc-289dd04b47ca)

This is great when you're deploying an app which uses a container image that you don't control.

