### PR TITLE
feat: support for --env-file on generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Examples:
 
 Flags:
       --build stringArray               An optional build context to use for the given container --build=container=./dir or --build=container={'"context":"./dir"}
+      --env-file string                 Location to store a skeleton .env file for compose - this will override existing content
   -h, --help                            help for generate
       --image string                    An optional container image to use for any container with image == '.'
   -o, --output string                   The output file to write the composed compose file to (default "compose.yaml")

--- a/examples/02-environment/README.md
+++ b/examples/02-environment/README.md
@@ -82,3 +82,11 @@ Attaching to compose-hello-world-1
 compose-hello-world-1  | Hello Bob!
 compose-hello-world-1  | Hello Bob!
 ```
+
+`score-compose` can generate the initial env file for you if you're not sure what variables are used. To do this, specify the `--env-file` flag when running the `generate` subcommand.
+
+```
+$ score-compose generate --env-file sample.env
+$ cat sample.env
+NAME=
+```

--- a/internal/command/generate_test.go
+++ b/internal/command/generate_test.go
@@ -54,6 +54,7 @@ Examples:
 
 Flags:
       --build stringArray               An optional build context to use for the given container --build=container=./dir or --build=container={'"context":"./dir"}
+      --env-file string                 Location to store a skeleton .env file for compose - this will override existing content
   -h, --help                            help for generate
       --image string                    An optional container image to use for any container with image == '.'
   -o, --output string                   The output file to write the composed compose file to (default "compose.yaml")


### PR DESCRIPTION
This PR adds a backwards compatibility feature to generate that was present in the existing run command.

Now you can specify `--env-file` to output a compose-style environment file that can be filled in with relevant values.

It's recommended to check this into the repo along with the score file so that developers know what to provide here.

eg: with a score file like:

```
apiVersion: score.dev/v1b1

metadata:
  name: hello-world

containers:
  hello:
    image: busybox
    variables:
      LOG_LEVEL: ${resources.env.LOG_LEVEL}
      STAGE: ${resources.env.STAGE}

resources:
  env:
    type: environment
```

Running with `--env-file .env` will output:

```
LOG_LEVEL=
STAGE=
```

These should both be filled in appropriately before running `docker compose up`

