### PR TITLE
feat: support /-separated annotation keys in metadata reference

### DIFF
--- a/examples/02-environment/README.md
+++ b/examples/02-environment/README.md
@@ -2,7 +2,9 @@
 
 When `docker-compose` spins-up the service, it is possible to pass some information from the host to the container via the environment variables. These variables can then be accessed by programs running in the container.
 
-The `containers.*.variables` section supports placeholder interpolation using `${..}` syntax. This can be used to access outputs from metadata or resources. The `environment` resource to collect them from the current shell:
+The `containers.*.variables` section supports placeholder interpolation using `${..}` syntax. This can be used to access outputs from metadata or resources. The placeholder syntax can be escaped with a double-$ like `$${..}`.
+
+The `environment` resource to collect them from the current shell:
 
 ```yaml
 apiVersion: score.dev/v1b1


### PR DESCRIPTION
This PR expands the set of supported characters inside a `${..}` placeholder and makes the templating system more predictable and reliable.

In the past a placeholder like `${x y z}` would just be returned as `${x y z}` without any error or modification. Now we will steer users towards escaping it instead if this is the desired behavior: `$${x y z}`.

As a side effect this fixes #91 as it now allows the forward slash inside the placeholder.