### PR TITLE
fix: resolve file source relative to the score file

### DIFF
--- a/examples/03-files/README.md
+++ b/examples/03-files/README.md
@@ -4,7 +4,7 @@ Score workloads can bind-mount files into running containers. Files using `conte
 
 This is invaluable when configuring containers whose images you don't control or cannot modify further.
 
-In the Score file below, two files are mounted, one with inline content, the other sourced from the local directory.
+In the Score file below, two files are mounted, one with inline content, the other sourced from the local directory relative to the input Score file.
 
 ```yaml
 apiVersion: score.dev/v1b1

--- a/internal/command/generate.go
+++ b/internal/command/generate.go
@@ -124,7 +124,10 @@ arguments.
 		currentState := &sd.State
 
 		// Now validate with score spec
-		for workloadName, spec := range workloadSpecs {
+		for i, workloadName := range workloadNames {
+			spec := workloadSpecs[workloadName]
+			inputFile := inputFiles[i]
+
 			// Ensure transforms are applied (be a good citizen)
 			if changes, err := schema.ApplyCommonUpgradeTransforms(spec); err != nil {
 				return fmt.Errorf("failed to upgrade spec: %w", err)
@@ -180,7 +183,7 @@ arguments.
 				}
 			}
 
-			currentState, err = currentState.WithWorkload(&out, nil, containerBuildContexts)
+			currentState, err = currentState.WithWorkload(&out, &inputFile, containerBuildContexts)
 			if err != nil {
 				return fmt.Errorf("failed to add workload '%s': %w", workloadName, err)
 			}

--- a/internal/command/generate_test.go
+++ b/internal/command/generate_test.go
@@ -170,6 +170,7 @@ services:
 	sd, ok, err := project.LoadStateDirectory(td)
 	assert.NoError(t, err)
 	assert.True(t, ok)
+	assert.Equal(t, "score.yaml", *sd.State.Workloads["example"].File)
 	assert.Len(t, sd.State.Workloads, 1)
 	assert.Len(t, sd.State.Resources, 1)
 }


### PR DESCRIPTION
The score specification intends that the container file elements that have a source path are resolved relative to the source of the score file and not just relative to the working directory. This ensures that `score-compose generate sub-component/score.yaml` works as expected.

This PR fixes this by tracking the source file info in the state object and using this when resolving the source file.