### PR TITLE
feat: support service-port.default resource provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ The `score.yaml` specification file can be executed against a _Score Implementat
 
 `score-compose` comes with out-of-the-box support for:
 
-| Type        | Class   | Params | Output                                                                                                                                                          |
-|-------------|---------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| environment | default | (none) | `${KEY}`                                                                                                                                                        |
-| service     | !       | !      | Not supported yet, tracked in [#87](https://github.com/score-spec/score-compose/issues/87).                                                                     |
-| volume      | *       | (none) | `source`                                                                                                                                                        |
-| redis       | *       | (none) | `host`, `port`, `username`, `password`                                                                                                                          | 
-| postgres    | *       | (none) | `host`, `port`, `name` (aka `database`), `username`, `password`                                                                                                 |
-| s3          | *       | (none) | `endpoint`, `access_key_id`, `secret_key`, `bucket`, with `region=""`, `aws_access_key_id=<access_key_id>`, and `aws_secret_key=<secret_key>` for compatibility |
+| Type         | Class   | Params             | Output                                                                                                                                                          |
+|--------------|---------|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| environment  | default | (none)             | `${KEY}`                                                                                                                                                        |
+| service-port | default | `workload`, `port` | `hostname`, `port`                                                                                                                                              |
+| volume       | *       | (none)             | `source`                                                                                                                                                        |
+| redis        | *       | (none)             | `host`, `port`, `username`, `password`                                                                                                                          | 
+| postgres     | *       | (none)             | `host`, `port`, `name` (aka `database`), `username`, `password`                                                                                                 |
+| s3           | *       | (none)             | `endpoint`, `access_key_id`, `secret_key`, `bucket`, with `region=""`, `aws_access_key_id=<access_key_id>`, and `aws_secret_key=<secret_key>` for compatibility |
 
 ## ![Installation](docs/images/install.svg) Installation
 
@@ -54,6 +54,7 @@ See the [examples](./examples) for more examples of using Score and provisioning
 - [05-volume-mounts](examples/05-volume-mounts) - an example of an "empty-dir" volume resource with `type: volume`
 - [06-resource-provisioning](examples/06-resource-provisioning) - detailed example and information about resource provisioning and the operation of the `template://` and `cmd://` provisioners
 - [07-overrides](examples/07-overrides) - details of how to override aspects of the input Score file and output Docker compose files
+- [08-service-port-resource](examples/08-service-port-resource) - an example of using the `service` resource type to link between workloads
 
 If you're getting started, you can use `score-compose init` to create a basic `score.yaml` file in the current directory along with a `.score-compose/` working directory.
 

--- a/examples/08-service-port-resource/README.md
+++ b/examples/08-service-port-resource/README.md
@@ -1,0 +1,68 @@
+# 08 - Service Port resource example
+
+The `service-port` resource type can be used to link between workloads using the advertised service ports. In score-compose we resolve this to the workload hostname and the target port of the named service port. Errors are thrown if the named workload or port doesn't exist yet.
+
+Other Score implementations may map this to a hostname and port for an appropriate internal load balancer. 
+
+In this example, we have two workloads:
+
+**A - an nginx server that advertises its http port as a service port**
+
+```yaml
+apiVersion: score.dev/v1b1
+metadata:
+  name: workload-a
+containers:
+  example:
+    image: nginx
+service:
+  ports:
+    web:
+      port: 8080
+      targetPort: 80
+```
+
+**and B - a service that wants to call workload A**
+
+```yaml
+apiVersion: score.dev/v1b1
+metadata:
+  name: workload-b
+containers:
+  example:
+    image: busybox
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do wget $${DEPENDENCY_URL} || true; sleep 5; done"]
+    variables:
+      DEPENDENCY_URL: "http://${resources.dependency.hostname}:${resources.dependency.port}"
+resources:
+  dependency:
+    type: service-port
+    params:
+      workload: workload-a
+      port: web
+```
+
+Here we use a service dependency to identify the service port on `workload-a` and translate that into the target port to be called.
+
+When we run `score-compose init; score-compose generate score*.yaml`, the resulting compose file contains:
+
+```yaml
+name: temptest
+services:
+    workload-a-example:
+        image: nginx
+    workload-b-example:
+        command:
+            - -c
+            - while true; do wget $${DEPENDENCY_URL} || true; sleep 5; done
+        entrypoint:
+            - /bin/sh
+        environment:
+            DEPENDENCY_URL: http://workload-a-example:80
+        image: busybox
+```
+
+And when run, the logs show `workload-b` requesting the index page from the nginx server every 5 seconds.
+
+**NOTE**: no dependency relationship is created between the workloads, because Score assumes these workloads may start or restart in any order. Like all good software, the services should be implemented in a way that allows them to start up without the dependency being immediately available. In this case we use `|| true` in the wget statement to ensure `workload-b` retries the request.

--- a/examples/08-service-port-resource/score.yaml
+++ b/examples/08-service-port-resource/score.yaml
@@ -1,0 +1,35 @@
+# Score provides a developer-centric and platform-agnostic 
+# Workload specification to improve developer productivity and experience. 
+# Score eliminates configuration management between local and remote environments.
+#
+# Specification reference: https://docs.score.dev/docs/reference/score-spec-reference/
+---
+
+# Score specification version
+apiVersion: score.dev/v1b1
+
+metadata:
+  name: example
+
+containers:
+  hello-world:
+    image: nginx:latest
+
+    # Uncomment the following for a custom entrypoint command
+    # command: []
+
+    # Uncomment the following for custom arguments
+    # args: []
+
+    # Environment variables to inject into the container
+    variables:
+      EXAMPLE_VARIABLE: "example-value"
+
+service:
+  ports:
+    # Expose the http port from nginx on port 8080
+    www:
+      port: 8080
+      targetPort: 80
+
+resources: {}

--- a/examples/08-service-port-resource/scoreA.yaml
+++ b/examples/08-service-port-resource/scoreA.yaml
@@ -1,0 +1,11 @@
+apiVersion: score.dev/v1b1
+metadata:
+  name: workload-a
+containers:
+  example:
+    image: nginx
+service:
+  ports:
+    web:
+      port: 8080
+      targetPort: 80

--- a/examples/08-service-port-resource/scoreB.yaml
+++ b/examples/08-service-port-resource/scoreB.yaml
@@ -1,0 +1,16 @@
+apiVersion: score.dev/v1b1
+metadata:
+  name: workload-b
+containers:
+  example:
+    image: busybox
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do wget $${DEPENDENCY_URL} || true; sleep 5; done"]
+    variables:
+      DEPENDENCY_URL: "http://${resources.dependency.hostname}:${resources.dependency.port}"
+resources:
+  dependency:
+    type: service-port
+    params:
+      workload: workload-a
+      port: web

--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -36,6 +36,22 @@
       labels:
         dev.score.compose.res.uid: {{ .Uid }}
 
+# The default provisioner for service resources, this expects a workload and port name and will return the hostname and
+# port required to contact it. This will validate that the workload and port exist, but won't enforce a dependency
+# relationship yet.
+- uri: template://default-provisioners/service-port
+  type: service-port
+  class: default
+  outputs: |
+    {{ if not .Params.workload }}{{ fail "expected 'workload' param for the target workload name" }}{{ end }}
+    {{ if not .Params.port }}{{ fail "expected 'port' param for the name of the target workload service port" }}{{ end }}
+    {{ $w := (index .WorkloadServices .Params.workload) }}
+    {{ if not $w }}{{ fail "unknown workload" }}{{ end }}
+    {{ $p := (index $w.Ports .Params.port) }}
+    {{ if not $p }}{{ fail "unknown service port" }}{{ end }}
+    hostname: {{ $w.ServiceName | quote }}
+    port: {{ $p.TargetPort }}
+
 # The default redis provisioner adds a redis service to the project which returns a host, port, username, and password.
 - uri: template://default-provisioners/redis
   # By default, match all redis types regardless of class and id. If you want to override this, create another

--- a/internal/command/generate_examples_test.go
+++ b/internal/command/generate_examples_test.go
@@ -146,6 +146,24 @@ services:
 `,
 		},
 		{
+			subDir: "08-service-port-resource",
+			adds:   []string{"scoreA.yaml", "scoreB.yaml"},
+			expected: `name: 08-service-port-resource
+services:
+    workload-a-example:
+        image: nginx
+    workload-b-example:
+        command:
+            - -c
+            - while true; do wget $${DEPENDENCY_URL} || true; sleep 5; done
+        entrypoint:
+            - /bin/sh
+        environment:
+            DEPENDENCY_URL: http://workload-a-example:80
+        image: busybox
+`,
+		},
+		{
 			subDir: "09-dns-and-route",
 			adds:   []string{"score.yaml"},
 		},


### PR DESCRIPTION
The `service-port` resource type allows a workload to reference a service port exposed by another workload.

**NOTE**: this is similar to the `service` resource type from score-humanitec, but has a slightly different contract since it targets a specific port. We will consider implementing service-port in humanitec in the future.

For example, if workload-b exposes a "web" port with port 80 -> targetPort 8080, this service resource will resolve to the docker compose service name of the workload and the target port on the network interface to call for the "web" port. 

Another implementation such as score-helm, might convert this into the particular cluster-ip service provisioned for that service port and return it's name and port 80.

Appropriate errors are thrown if the required workload hasn't been added to the project yet!
