### PR TITLE
fix: upgrade score-go and move special 2-part volume placeholder impl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/compose-spec/compose-go/v2 v2.0.0-rc.8
 	github.com/imdario/mergo v0.3.13
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/score-spec/score-go v1.5.0
+	github.com/score-spec/score-go v1.5.1
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
-github.com/score-spec/score-go v1.5.0 h1:5IybImptuFomQghh4Zbyux9ZU5uTBYvVYw2DVcdo70c=
-github.com/score-spec/score-go v1.5.0/go.mod h1:3QSPH5QVMIX7FdhktLLFtjLQTL1/ENqrWDe5lSdZGFc=
+github.com/score-spec/score-go v1.5.1 h1:0HuNihM/bDA6z5CPYQlVN0P4V0/AkfLT8DjDxnkZ03Q=
+github.com/score-spec/score-go v1.5.1/go.mod h1:3QSPH5QVMIX7FdhktLLFtjLQTL1/ENqrWDe5lSdZGFc=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=

--- a/internal/compose/convert_test.go
+++ b/internal/compose/convert_test.go
@@ -252,7 +252,7 @@ func TestScoreConvert(t *testing.T) {
 				Containers: score.WorkloadContainers{
 					"test": score.Container{
 						Image:   "busybox",
-						Volumes: []score.ContainerVolumesElem{{Source: "data", Target: "/mnt/data"}},
+						Volumes: []score.ContainerVolumesElem{{Source: "${resources.data}", Target: "/mnt/data"}},
 					},
 				},
 			},
@@ -266,7 +266,7 @@ func TestScoreConvert(t *testing.T) {
 				Containers: score.WorkloadContainers{
 					"test": score.Container{
 						Image:   "busybox",
-						Volumes: []score.ContainerVolumesElem{{Source: "data", Target: "/mnt/data"}},
+						Volumes: []score.ContainerVolumesElem{{Source: "${resources.data}", Target: "/mnt/data"}},
 					},
 				},
 				Resources: map[string]score.Resource{"data": {Type: "thing"}},


### PR DESCRIPTION
There was previously a special case in score-go for converting 2 part placeholders like `${resources.foo}` into just "foo". This was a legacy behavior due to the way volumes are linked into containers. However this was a behavior only needed by score-compose and incompatible with other score implementations. So in 1.5.1 of score-go we removed the special casing and now throw the original error and move the handling of this field specifically into the volume field substitution in score-compose. This means we restrict this special casing into only the particular field and resource type combination that need it 👍 

Going forwards the `${resources.foo}` placeholder will throw an error in most cases because it expects an output lookup key. Certain resources implemented by output-lookup-functions may now handle the 2-part lookup specifically, but this is not a limited case rather than general behavior.

