### PR TITLE
fix(route-provisioner): support Prefix vs Exact routing

### DIFF
--- a/examples/09-dns-and-route/README.md
+++ b/examples/09-dns-and-route/README.md
@@ -34,6 +34,8 @@ This adds an additional nginx service to the compose file which contains an HTTP
 
 By default, this listens on http://localhost:8080.
 
+By default, this uses a `Prefix` route matching type so `/` can match `/any/request/path` but you can add a `score-compose.score.dev/route-provisioner-path-type: Exact` annotation to a Route to restrict this behavior.
+
 ## Limitations
 
 Technically, the `dns` resource should produce random or appropriate hostnames for each dns resource. However, this implementation always generates localhost since we don't by default create real DNS names or modify the local /etc/hosts file.

--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -326,7 +326,8 @@
       {{ $target := (printf "%s:%d" $targetHost $targetPort) }}
       {{ $hBefore := dig .Init.sk "hosts" (dict) .Shared }}
       {{ $rBefore := dig .Params.host (dict) $hBefore }}
-      {{ $inner := dict "path" .Params.path "target" $target "port" $targetPort }}
+      {{ $pathType := dig "score-compose.score.dev/route-provisioner-path-type" "Prefix" (dig "annotations" (dict) (.Metadata | default (dict))) }}
+      {{ $inner := dict "path" .Params.path "target" $target "port" $targetPort "path_type" $pathType }}
       {{ $rAfter := (merge $rBefore (dict .Uid $inner)) }}
       {{ $hAfter := (merge $hBefore (dict .Params.host $rAfter)) }}
       hosts: {{ $hAfter | toRawJson }}
@@ -363,14 +364,16 @@
           }
           
           {{ range $k, $v := $r }}
+          # the basic path variant, "/" or "/one/two"
           location = {{ index $v "path" }} {
             set $backend {{ index $v "target" }};
             rewrite ^{{ index $v "path" }}(.*)$ /$1 break;
             proxy_pass http://$backend;
           }
 
-          {{ if not (eq (index $v "path") "/") }}
-          location {{ index $v "path" }}/ {
+          # The prefix match variants are included by default but can be excluded via 'score-compose.score.dev/route-provisioner-path-type' annotation
+          {{ if eq (index $v "path_type") "Prefix" }}
+          location {{ index $v "path" | trimSuffix "/" }}/ {
             set $backend {{ index $v "target" }};
             rewrite ^{{ index $v "path" }}/(.*)$ /$1 break;
             proxy_pass http://$backend;


### PR DESCRIPTION
The existing route provisioner was inconsistent in behavior and was doing Prefix matching on non-/ routes by default, not providing any Prefix matching on the / route, and not supporting any control mechanisms either way.

This PR fixes this so that we can do:

```
apiVersion: score.dev/v1b1
metadata:
  name: example
containers:
  web:
    image: ealen/echo-server:0.9.2
service:
  ports:
    web:
      port: 8080
      targetPort: 80
resources:
  dns:
    type: dns
  route2:
    type: route
    params:
      host: ${resources.dns.host}
      port: web
      path: /first
  route3:
    type: route
    metadata:
      annotations:
        score-compose.score.dev/route-provisioner-path-type: Exact
    params:
      host: ${resources.dns.host}
      port: web
      path: /second
```

And using curl we can see that:

- `curl http://localhost:8080/| jq .http.originalUrl` -> 404
- `curl http://localhost:8080/first | jq .http.originalUrl` -> `"/"`
- `curl http://localhost:8080/first/subpath | jq .http.originalUrl` -> `"/subpath"`
- `curl http://localhost:8080/second | jq .http.originalUrl` -> `"/"`
- `curl http://localhost:8080/second/subpath | jq .http.originalUrl` -> 404

Fixes #107 .