### PR TITLE
fix: add public schema grant to postgres resource provisioner

### DIFF
--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -146,6 +146,8 @@
       SELECT 'CREATE DATABASE "{{ .State.database }}"' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '{{ .State.database }}')\gexec
       SELECT $$CREATE USER "{{ .State.username }}" WITH PASSWORD '{{ .State.password }}'$$ WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '{{ .State.username }}')\gexec
       GRANT ALL PRIVILEGES ON DATABASE "{{ .State.database }}" TO "{{ .State.username }}";
+      \connect "{{ .State.database }}";
+      GRANT ALL ON SCHEMA public TO "{{ .State.username }}";
   # Ensure the data volume exists
   volumes: |
     {{ dig .Init.sk "instanceServiceName" "" .Shared }}-data:


### PR DESCRIPTION
While testing this with a new service I found that the generated user doesn't have access to the public schema in the postgres database.

This PR adds the misisng lines during setup.
