### PR TITLE
fix: remove path rewrite from route provisioner

### DIFF
--- a/examples/09-dns-and-route/README.md
+++ b/examples/09-dns-and-route/README.md
@@ -23,18 +23,18 @@ resources:
   route:
     type: route
     params:
-      path: /subpath
+      path: /my/[^/]+/path
       host: ${resources.dns.host}
       port: web
 ```
 
-The `route` resource indicates the host from the dns resource, and the sub path to route. While the `web` port is the one exposed by the service.
+The `route` resource indicates the host from the dns resource, and the path to route. While the `web` port is the one exposed by the service.
 
 This adds an additional nginx service to the compose file which contains an HTTP routing specification for the hostname and path combinations.
 
-By default, this listens on http://localhost:8080.
+By default, this listens on http://localhost:8080. And in the example will route paths like `/my/fizz/path`, `/my/buzz/path/thing`
 
-By default, this uses a `Prefix` route matching type so `/` can match `/any/request/path` but you can add a `score-compose.score.dev/route-provisioner-path-type: Exact` annotation to a Route to restrict this behavior.
+By default, this uses a `Prefix` route matching type so `/` can match `/any/request/path` but you can add a `score-compose.score.dev/route-provisioner-path-type: Exact` annotation to a Route to restrict this behavior to just an exact match.
 
 ## Limitations
 

--- a/examples/09-dns-and-route/score.yaml
+++ b/examples/09-dns-and-route/score.yaml
@@ -15,6 +15,6 @@ resources:
   route:
     type: route
     params:
-      path: /subpath
+      path: /my/[^/]+/path
       host: ${resources.dns.host}
       port: web

--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -367,17 +367,15 @@
           
           {{ range $k, $v := $r }}
           # the basic path variant, "/" or "/one/two"
-          location = {{ index $v "path" }} {
+          location ~ ^{{ index $v "path" }}$ {
             set $backend {{ index $v "target" }};
-            rewrite ^{{ index $v "path" }}(.*)$ /$1 break;
             proxy_pass http://$backend;
           }
 
           # The prefix match variants are included by default but can be excluded via 'score-compose.score.dev/route-provisioner-path-type' annotation
           {{ if eq (index $v "path_type") "Prefix" }}
-          location {{ index $v "path" | trimSuffix "/" }}/ {
+          location ~ ^{{ index $v "path" | trimSuffix "/" }}/.* {
             set $backend {{ index $v "target" }};
-            rewrite ^{{ index $v "path" }}/(.*)$ /$1 break;
             proxy_pass http://$backend;
           }
           {{ end }}

--- a/internal/command/generate_test.go
+++ b/internal/command/generate_test.go
@@ -846,12 +846,12 @@ resources:
 	// validate that the wildcard routes don't exist for /third
 	raw, err := os.ReadFile(filepath.Join(td, ".score-compose", "mounts", instanceServiceName, "nginx.conf"))
 	assert.NoError(t, err)
-	assert.Contains(t, string(raw), `location = /first`)
-	assert.Contains(t, string(raw), `location /first/`)
-	assert.Contains(t, string(raw), `location = /second`)
-	assert.Contains(t, string(raw), `location /second/`)
-	assert.Contains(t, string(raw), `location = /third`)
-	assert.NotContains(t, string(raw), `location /third/`)
+	assert.Contains(t, string(raw), `location ~ ^/first$`)
+	assert.Contains(t, string(raw), `location ~ ^/first/.*`)
+	assert.Contains(t, string(raw), `location ~ ^/second$`)
+	assert.Contains(t, string(raw), `location ~ ^/second/.*`)
+	assert.Contains(t, string(raw), `location ~ ^/third$`)
+	assert.NotContains(t, string(raw), `location ~ ^/third/.*`)
 
 	t.Run("validate compose spec", func(t *testing.T) {
 		if os.Getenv("NO_DOCKER") != "" {


### PR DESCRIPTION
I made a mistake in the initial implementation of the route provisioner. I had written it so that it removed the matched path (and it also didn't work at all with regex routes).

After looking at the general assumptions of the Humanitec score docs and existing route provisioners in Humanitec I can see that the expectation is actually that this is a route match that supports regex and simply proxies the request without rewriting the path.

Naturally, users are _welcome_ to add a custom provisioner that does this slightly differently, but the basic case should be to support patterns and regex like this:

```
resources:
  animals-route:
    type: route
    params:
      host: api.example.com
      path: /projects/[^/]+/animals
      port: 8080
  fruit-route:
    type: route
    params:
      host: api.example.com
      path: /projects/[^/]+/fruit
      port: 8080
```