### PR TITLE
feat: support random dns names via rfc6761-6.3

### DIFF
--- a/examples/04-multiple-workloads/README.md
+++ b/examples/04-multiple-workloads/README.md
@@ -24,7 +24,7 @@ $ score-compose init
 $ score-compose generate score.yaml
 ```
 
-Score compose also supports multiple workloads in the same project directory. These can be added one at a time to the project but must have independent workload names. Containers from different workloads run in different network namespaces.
+Score compose also supports multiple workloads in the same project directory. These can be added one at a time to the project since `score-compose generate` is _additive_ but must have independent workload names. Containers from different workloads run in different network namespaces.
 
 A second `score2.yaml` file can be written:
 
@@ -39,11 +39,34 @@ containers:
     image: "nginx:latest"
     variables:
       NGINX_PORT: "8080"
-
 ```
 
 ```console
 $ score-compose generate score2.yaml
 ```
 
-View the `score-compose generate --help` text for more information about overriding properties and Score workload contents.
+The output compose file appears as below. Notice that all 3 containers are present and that the `hello-world-2` doesn't share its network with the other containers.
+
+```yaml
+name: 04-multiple-workloads
+services:
+    hello-world-2-first:
+        environment:
+            NGINX_PORT: "8080"
+        image: nginx:latest
+    hello-world-first:
+        environment:
+            NGINX_PORT: "8080"
+        image: nginx:latest
+    hello-world-second:
+        environment:
+            NGINX_PORT: "8081"
+        image: nginx:latest
+        network_mode: service:hello-world-first
+```
+
+View the `score-compose generate --help` text for more information about overriding properties and Score workload contents. If no special options are required, the generate command can add multiple Score files at once:
+
+```console
+score-compose generate score*.yaml
+```

--- a/examples/09-dns-and-route/README.md
+++ b/examples/09-dns-and-route/README.md
@@ -11,12 +11,18 @@ apiVersion: score.dev/v1b1
 metadata:
   name: hello-world
 service:
-  web:
-    port: 8080
-    targetPort: 80
+  ports:
+    web:
+      port: 8080
+      targetPort: 80
 containers:
   web:
     image: nginx
+    files:
+      - target: /usr/share/nginx/html/my/fizz/path/index.html
+        content: fizz
+      - target: /usr/share/nginx/html/my/buzz/path/index.html
+        content: buzz
 resources:
   dns:
     type: dns
@@ -32,14 +38,15 @@ The `route` resource indicates the host from the dns resource, and the path to r
 
 This adds an additional nginx service to the compose file which contains an HTTP routing specification for the hostname and path combinations.
 
-By default, this listens on http://localhost:8080. And in the example will route paths like `/my/fizz/path`, `/my/buzz/path/thing`
+By default, this listens on http://localhost:8080 and in the example will route paths like `/my/fizz/path`, `/my/buzz/path/thing`
 
 By default, this uses a `Prefix` route matching type so `/` can match `/any/request/path` but you can add a `score-compose.score.dev/route-provisioner-path-type: Exact` annotation to a Route to restrict this behavior to just an exact match.
 
-## Limitations
+When running this compose project, we can test these routes using curl (in this instance the generated dns name was `dnsmntq6e`):
 
-Technically, the `dns` resource should produce random or appropriate hostnames for each dns resource. However, this implementation always generates localhost since we don't by default create real DNS names or modify the local /etc/hosts file.
-
-This means that if there are multiple workloads with overlapping path routing, they will fail or only one will resolve correctly.
-
-To get around this, you may inject your own dns resource provisioner with appropriate behavior for your environment, the only requirement is that it returns a `host` output string that is resolvable.
+```shell
+$ curl http://dnsmntq6e.09-dns-and-route.localhost:8080/my/fizz/path/
+fizz
+$ curl http://dnsmntq6e.09-dns-and-route.localhost:8080/my/buzz/path/
+buzz
+```

--- a/examples/09-dns-and-route/README.md
+++ b/examples/09-dns-and-route/README.md
@@ -38,15 +38,26 @@ The `route` resource indicates the host from the dns resource, and the path to r
 
 This adds an additional nginx service to the compose file which contains an HTTP routing specification for the hostname and path combinations.
 
-By default, this listens on http://localhost:8080 and in the example will route paths like `/my/fizz/path`, `/my/buzz/path/thing`
+By default, this listens on http://localhost:8080 and in the example will route paths like `/my/fizz/path`, `/my/buzz/path/thing`. The port 8080 unfortunately cannot be changed without modifying the provisioner in the default provisioners file after running `score-compose init`.
 
 By default, this uses a `Prefix` route matching type so `/` can match `/any/request/path` but you can add a `score-compose.score.dev/route-provisioner-path-type: Exact` annotation to a Route to restrict this behavior to just an exact match.
 
 When running this compose project, we can test these routes using curl (in this instance the generated dns name was `dnsmntq6e`):
 
 ```shell
-$ curl http://dnsmntq6e.09-dns-and-route.localhost:8080/my/fizz/path/
+$ curl http://dnsmntq6e.localhost:8080/my/fizz/path/
 fizz
-$ curl http://dnsmntq6e.09-dns-and-route.localhost:8080/my/buzz/path/
+$ curl http://dnsmntq6e.localhost:8080/my/buzz/path/
 buzz
+```
+
+## Fixed DNS names
+
+If you want a fixed DNS name, you can add a new DNS provisioner to your `.score-compose/0-custom-provisioners.yaml` file:
+
+```yaml
+- uri: template://custom-dns
+  type: dns
+  outputs: |
+    host: api.localhost
 ```

--- a/examples/09-dns-and-route/score.yaml
+++ b/examples/09-dns-and-route/score.yaml
@@ -9,6 +9,11 @@ service:
 containers:
   web:
     image: nginx
+    files:
+      - target: /usr/share/nginx/html/my/fizz/path/index.html
+        content: fizz
+      - target: /usr/share/nginx/html/my/buzz/path/index.html
+        content: buzz
 resources:
   dns:
     type: dns

--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -300,8 +300,12 @@
 - uri: template://default-provisioners/dns
   type: dns
   class: default
+  init: |
+    randomHostname: dns{{ randAlphaNum 6 | lower }}.localhost
+  state: |
+    instanceHostname: {{ dig "instanceHostname" .Init.randomHostname .State | quote }}
   outputs: |
-    host: localhost
+    host: {{ .State.instanceHostname }}
 
 # The default route provisioner sets up an nginx service with an HTTP service that can route on our prefix paths.
 # It assumes the hostnames and routes provided have no overlaps. Weird behavior may happen if there are overlaps.
@@ -312,14 +316,14 @@
     randomServiceName: routing-{{ randAlphaNum 6 }}
     sk: default-provisioners-routing-instance
     {{ if not (regexMatch "^/|(/([^/]+))+$" .Params.path) }}{{ fail "params.path start with a / but cannot end with /" }}{{ end }}
-    {{ if not (regexMatch "^[a-z0-9_.-]{1,253}$" .Params.host) }}{{ fail "params.host must be a valid hostname" }}{{ end }}
+    {{ if not (regexMatch "^[a-z0-9_.-]{1,253}$" .Params.host) }}{{ fail (cat "params.host must be a valid hostname but was" .Params.host) }}{{ end }}
     {{ $ports := (index .WorkloadServices .SourceWorkload).Ports }}
     {{ if not $ports }}{{ fail "no service ports exist" }}{{ end }}
     {{ $port := index $ports (print .Params.port) }}
     {{ if not $port.TargetPort }}{{ fail "params.port is not a named service port" }}{{ end }}
   shared: |
     {{ .Init.sk }}:
-      instancePort: 8080
+      instancePort: {{ dig .Init.sk "instancePort" 8080 .Shared }}
       instanceServiceName: {{ dig .Init.sk "instanceServiceName" .Init.randomServiceName .Shared | quote }}
       {{ $targetHost := (index .WorkloadServices .SourceWorkload).ServiceName }}
       {{ $ports := (index .WorkloadServices .SourceWorkload).Ports }}


### PR DESCRIPTION
In the initial implementation of the dns provisioner, we limited it to generated localhost domains because any other domains may not resolve to the loopback address. We detailed this as a limitation.

However we've recently found that almost all systems today respect https://datatracker.ietf.org/doc/html/rfc6761#section-6.3 which allows *.localhost to resolve to the loopback addresses!

So in this PR we upgrade the dns provisioner and the docs for the routing example so that we can generate a hostname that looks like `dns<random 6>.localhost`.

This allows us to more easily have 2 different score workloads in the same project with different routing. 

Think of an API and an APP (UI) together which would be a common use case.