### PR TITLE
feat: added rabbitmq/amqp provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,17 @@ The `score.yaml` specification file can be executed against a _Score Implementat
 
 `score-compose` comes with out-of-the-box support for:
 
-| Type         | Class   | Params             | Output                                                                                                                                                          |
-|--------------|---------|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| environment  | default | (none)             | `${KEY}`                                                                                                                                                        |
-| service-port | default | `workload`, `port` | `hostname`, `port`                                                                                                                                              |
-| volume       | *       | (none)             | `source`                                                                                                                                                        |
-| redis        | *       | (none)             | `host`, `port`, `username`, `password`                                                                                                                          | 
-| postgres     | *       | (none)             | `host`, `port`, `name` (aka `database`), `username`, `password`                                                                                                 |
-| s3           | *       | (none)             | `endpoint`, `access_key_id`, `secret_key`, `bucket`, with `region=""`, `aws_access_key_id=<access_key_id>`, and `aws_secret_key=<secret_key>` for compatibility |
+| Type         | Class   | Params                 | Output                                                                                                                                                          |
+|--------------|---------|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| environment  | default | (none)                 | `${KEY}`                                                                                                                                                        |
+| service-port | default | `workload`, `port`     | `hostname`, `port`                                                                                                                                              |
+| volume       | default | (none)                 | `source`                                                                                                                                                        |
+| redis        | default | (none)                 | `host`, `port`, `username`, `password`                                                                                                                          |
+| postgres     | default | (none)                 | `host`, `port`, `name` (aka `database`), `username`, `password`                                                                                                 |
+| s3           | default | (none)                 | `endpoint`, `access_key_id`, `secret_key`, `bucket`, with `region=""`, `aws_access_key_id=<access_key_id>`, and `aws_secret_key=<secret_key>` for compatibility |
+| dns          | default | (none)                 | `host`                                                                                                                                                          |
+| route        | default | `host`, `path`, `port` |                                                                                                                                                                 |
+| amqp         | default | (none)                 | `host`, `port`, `vhost`, `username`, `password`                                                                                                                 |
 
 ## ![Installation](docs/images/install.svg) Installation
 

--- a/examples/10-amqp-rabbitmq/README.md
+++ b/examples/10-amqp-rabbitmq/README.md
@@ -33,4 +33,6 @@ resources:
         "compose.score.dev/publish-management-port": "15672"
 ```
 
+While you can add this to your main Score file, it's a good idea to apply this as an `--overrides-file`. 
+
 The default user with username `guest`, password `guest` will be available. This is very useful for debugging applications.

--- a/examples/10-amqp-rabbitmq/README.md
+++ b/examples/10-amqp-rabbitmq/README.md
@@ -1,0 +1,36 @@
+# 10 - AMQP resource provisioning
+
+Many applications may require a connection to an AMQP protocol message broker. score-compose comes with a built-in
+provider for RabbitMQ using the public docker image.
+
+When this provider is used, it will generate a single RabbitMQ instance with a v-host per AMQP resource definition.
+
+```
+resources:
+  bus:
+    type: amqp
+```
+
+The provided outputs are `host`, `port`, `vhost`, `username`, and `password` and these can be assembled together into a 
+URI like `amqp://${resources.bus.username}:${resources.bus.password}@${resources.bus.host}:${resources.bus.port}/${resources.bus.vhost}`.
+
+The generated user has administrator permissions on the vhost.
+
+For more complicated configuration, it is recommended to copy the default rabbitmq provisioner to your own provisioners
+file and modify the configuration.
+
+## Accessing the AMQP and management ports
+
+By tagging your `amqp` resources with the publish-port annotations you can publish the ports on `localhost`:
+
+```yaml
+resources:
+  bus:
+    type: amqp
+    metadata:
+      annotations:
+        "compose.score.dev/publish-port": "5672"
+        "compose.score.dev/publish-management-port": "15672"
+```
+
+The default user with username `guest`, password `guest` will be available. This is very useful for debugging applications.

--- a/examples/10-amqp-rabbitmq/score.yaml
+++ b/examples/10-amqp-rabbitmq/score.yaml
@@ -1,0 +1,23 @@
+apiVersion: score.dev/v1b1
+
+metadata:
+  name: hello-world
+
+containers:
+  first:
+    image: nginx
+    variables:
+      CONNECT_1: amqp://${resources.amqp1.username}:${resources.amqp1.password}@${resources.amqp1.host}:${resources.amqp1.port}/${resources.amqp1.vhost}
+      CONNECT_2: amqp://${resources.amqp2.username}:${resources.amqp2.password}@${resources.amqp2.host}:${resources.amqp2.port}/${resources.amqp2.vhost}
+
+resources:
+  amqp1:
+    type: amqp
+    metadata:
+      annotations:
+        "compose.score.dev/publish-management-port": "15672"
+  amqp2:
+    type: amqp
+    metadata:
+      annotations:
+        "compose.score.dev/publish-management-port": "15672"

--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -41,7 +41,6 @@
 # relationship yet.
 - uri: template://default-provisioners/service-port
   type: service-port
-  class: default
   outputs: |
     {{ if not .Params.workload }}{{ fail "expected 'workload' param for the target workload name" }}{{ end }}
     {{ if not .Params.port }}{{ fail "expected 'port' param for the name of the target workload service port" }}{{ end }}
@@ -294,12 +293,95 @@
     - "Or enter {{ dig .Init.sk "instanceUsername" "" .Shared }} / {{ dig .Init.sk "instancePassword" "" .Shared }} at https://localhost:{{ .Init.publishPort }}"
     {{ end }}
 
+
+# The default AMQP provisioner provides a simple rabbitmq instance with default configuration and plugins.
+- uri: template://default-provisioners/rabbitmq
+  type: amqp
+  init: |
+    randomServiceName: rabbitmq-{{ randAlphaNum 6 }}
+    randomVHost: vhost-{{ randAlpha 8 }}
+    randomUsername: user-{{ randAlpha 8 }}
+    randomPassword: {{ randAlphaNum 16 | quote }}
+    sk: default-provisioners-rabbitmq
+    publishPort: {{ dig "annotations" "compose.score.dev/publish-port" "0" .Metadata | atoi }}
+    publishManagementPort: {{ dig "annotations" "compose.score.dev/publish-management-port" "0" .Metadata | atoi }}
+  state: |
+    vhost: {{ dig "database" .Init.randomVHost .State | quote }}
+    username: {{ dig "username" .Init.randomUsername .State | quote }}
+    password: {{ dig "password" .Init.randomPassword .State | quote }}
+  outputs: |
+    host: {{ dig .Init.sk "instanceServiceName" "" .Shared }}
+    port: 5672
+    vhost: {{ .State.vhost }}
+    username: {{ .State.username }}
+    password: {{ .State.password }}
+  shared: |
+    {{ .Init.sk }}:
+      instanceServiceName: {{ dig .Init.sk "instanceServiceName" .Init.randomServiceName .Shared | quote }}
+      instanceErlangCookie: {{ dig .Init.sk "instanceErlangCookie" (randAlpha 20) .Shared }}
+      {{ $publishPorts := (list) }}
+      {{ if ne .Init.publishPort 0 }}{{ $publishPorts = (append $publishPorts (dict "target" 5672 "published" .Init.publishPort)) }}{{ end }}
+      {{ $x := (dig "annotations" "compose.score.dev/publish-management-port" "0" .Metadata | atoi) }}
+      {{ if ne .Init.publishManagementPort 0 }}{{ $publishPorts = (append $publishPorts (dict "target" 15672 "published" .Init.publishManagementPort)) }}{{ end }}
+      publishPorts: {{ $publishPorts | toJson }}
+  volumes: |
+    {{ dig .Init.sk "instanceServiceName" "" .Shared }}-data:
+      driver: local
+  files: |
+    {{ dig .Init.sk "instanceServiceName" "" .Shared }}-db-scripts/{{ .State.vhost }}.sh: |
+      rabbitmqctl list_vhosts | grep {{ .State.vhost }} || rabbitmqctl add_vhost {{ .State.vhost }}
+      rabbitmqctl list_users | grep {{ .State.username }} || rabbitmqctl add_user {{ .State.username }} {{ .State.password }}
+      rabbitmqctl set_user_tags {{ .State.username }} administrator
+      rabbitmqctl set_permissions -p {{ .State.vhost }} {{ .State.username }} ".*" ".*" ".*"
+      rabbitmqctl set_topic_permissions -p {{ .State.vhost }} {{ .State.username }} ".*" ".*" ".*"
+  services: |
+    {{ dig .Init.sk "instanceServiceName" "" .Shared }}:
+      image: rabbitmq:3-management-alpine
+      restart: always
+      environment:
+        RABBITMQ_ERLANG_COOKIE: {{ dig .Init.sk "instanceErlangCookie" "" .Shared }}
+        RABBITMQ_DEFAULT_USER: guest
+        RABBITMQ_DEFAULT_PASS: guest
+      ports: {{ dig .Init.sk "publishPorts" "" .Shared | toJson}}
+      volumes:
+      - type: volume
+        source: {{ dig .Init.sk "instanceServiceName" "" .Shared }}-data
+        target: /var/lib/rabbitmq
+      healthcheck:
+        test: ["CMD-SHELL", "rabbitmq-diagnostics -q check_port_connectivity"]
+        interval: 2s
+        timeout: 5s
+        retries: 5
+    {{ dig .Init.sk "instanceServiceName" "" .Shared }}-init:
+      image: rabbitmq:3-management-alpine
+      entrypoint: ["/bin/sh"]
+      environment:
+        RABBITMQ_ERLANG_COOKIE: {{ dig .Init.sk "instanceErlangCookie" "" .Shared }}
+      command:
+      - "-c"
+      - |
+        set -exu
+        for s in /db-scripts/*.sh; do source $$s; done
+      depends_on:
+        {{ dig .Init.sk "instanceServiceName" "" .Shared }}:
+          condition: service_healthy
+          restart: true
+      labels:
+        dev.score.compose.labels.is-init-container: "true"
+      network_mode: service:{{ dig .Init.sk "instanceServiceName" "" .Shared }}
+      volumes:
+      - type: bind
+        source: {{ .MountsDirectory }}/{{ dig .Init.sk "instanceServiceName" "" .Shared }}-db-scripts
+        target: /db-scripts
+  info_logs: |
+    {{ if ne .Init.publishManagementPort 0 }}
+    - "Browse the rabbitmq UI at \"http://localhost:{{ .Init.publishManagementPort }}\""
+    {{ end }}
 # The default dns provisioner just outputs localhost as the hostname every time.
 # This is because without actual control of a dns resolver we can't do any accurate routing on any other name. This
 # can be replaced by a new provisioner in the future.
 - uri: template://default-provisioners/dns
   type: dns
-  class: default
   init: |
     randomHostname: dns{{ randAlphaNum 6 | lower }}.localhost
   state: |
@@ -311,7 +393,6 @@
 # It assumes the hostnames and routes provided have no overlaps. Weird behavior may happen if there are overlaps.
 - uri: template://default-provisioners/route
   type: route
-  class: default
   init: |
     randomServiceName: routing-{{ randAlphaNum 6 }}
     sk: default-provisioners-routing-instance

--- a/internal/command/generate_examples_test.go
+++ b/internal/command/generate_examples_test.go
@@ -167,6 +167,10 @@ services:
 			subDir: "09-dns-and-route",
 			adds:   []string{"score.yaml"},
 		},
+		{
+			subDir: "10-amqp-rabbitmq",
+			adds:   []string{"score.yaml"},
+		},
 	} {
 		t.Run(tc.subDir, func(t *testing.T) {
 			oldReader := rand.Reader


### PR DESCRIPTION
We have a usecase for a rabbitmq provisioner to generate a stateful message broker.

This PR adds it :)

When I run the example project I can see:

```
INFO: Writing new state directory '.score-compose'
INFO: Writing new state directory '.score-compose' with project name '10-amqp-rabbitmq'
INFO: Writing default provisioners yaml file '99-default.provisioners.yaml'
INFO: Found existing Score file './score.yaml'
INFO: Read more about the Score specification at https://docs.score.dev/docs/
INFO: Loaded state directory with docker compose project '10-amqp-rabbitmq'
INFO: Validated workload 'hello-world'
INFO: Successfully loaded 8 resource provisioners
INFO: Provisioned 2 resources
INFO: Converting workload 'hello-world' to Docker compose
```

```
[+] Running 4/6
 ⠧ Network 10-amqp-rabbitmq_default                   Created                                                                                                                                                                                                                                                                                                       12.7s
 ⠧ Volume "10-amqp-rabbitmq_rabbitmq-mVawRj-data"     Created                                                                                                                                                                                                                                                                                                       12.6s
 ✔ Container 10-amqp-rabbitmq-rabbitmq-mVawRj-1       Healthy                                                                                                                                                                                                                                                                                                        7.8s
 ✔ Container 10-amqp-rabbitmq-rabbitmq-mVawRj-init-1  Exited                                                                                                                                                                                                                                                                                                         7.8s
 ✔ Container 10-amqp-rabbitmq-wait-for-resources-1    Started                                                                                                                                                                                                                                                                                                       12.4s
 ✔ Container 10-amqp-rabbitmq-hello-world-first-1     Started
```

The logs for the init container show both users and vhosts being created:

```
Adding vhost "vhost-MHZYFUaA" ...
Adding user "user-kNyzYLtt" ...
Done. Don't forget to grant the user permissions to some virtual hosts! See 'rabbitmqctl help set_permissions' to learn more.
Setting tags for user "user-kNyzYLtt" to [administrator] ...
Setting permissions for user "user-kNyzYLtt" in vhost "vhost-MHZYFUaA" ...
Setting topic permissions on ".*" for user "user-kNyzYLtt" in vhost "vhost-MHZYFUaA" ...
Adding vhost "vhost-eOOSiqTF" ...
Adding user "user-uGCebmJZ" ...
Done. Don't forget to grant the user permissions to some virtual hosts! See 'rabbitmqctl help set_permissions' to learn more.
Setting tags for user "user-uGCebmJZ" to [administrator] ...
Setting permissions for user "user-uGCebmJZ" in vhost "vhost-eOOSiqTF" ...
Setting topic permissions on ".*" for user "user-uGCebmJZ" in vhost "vhost-eOOSiqTF" ...
```

And the port is available through the browser:

![image](https://github.com/score-spec/score-compose/assets/1651305/6de98a3f-32f2-4db4-9628-6ab8d209a27c)
