### PR TITLE
fix: assert volume based on outputs and not type

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The `score.yaml` specification file can be executed against a _Score Implementat
 | route        | default | `host`, `path`, `port` |                                                                                                                                                                 |
 | amqp         | default | (none)                 | `host`, `port`, `vhost`, `username`, `password`                                                                                                                 |
 
+These can be found in the default provisioners file. You are encouraged to write your own provisioners and add them to the `.score-compose` directory (with the `.provisioners.yaml` extension) or contribute them upstream to the [default.provisioners.yaml](internal/command/default.provisioners.yaml) file.
+
 ## ![Installation](docs/images/install.svg) Installation
 
 To install `score-compose`, follow the instructions as described in our [installation guide](https://docs.score.dev/docs/get-started/install/).

--- a/examples/05-volume-mounts/README.md
+++ b/examples/05-volume-mounts/README.md
@@ -1,14 +1,10 @@
 # 05 - Volume Mounts
 
-Along with `environment`, `volume` is one of the more common resource types supported by score-compose:
+Many Score projects require volume storage. Volume storage may be a tmpfs, a host bind mount, or a persistent and stateful volume. All three can be represented in score-compose depending on the provisioner.
 
-```yaml
-resources:
-  data:
-    type: volume
-```
+A default provisioner exists for a generic `volume` type which provisions a Docker volume and mounts it to the container.
 
-This provisions an empty Docker volume with a random name. This can be mounted into the container volumes section:
+As an example, the Score file may contain:
 
 ```yaml
 containers:
@@ -16,21 +12,49 @@ containers:
     volumes:
       - source: ${resources.data}
         target: /data
+resources:
+  data:
+    type: volume
 ```
 
-**NOTE**: the `${resources.data}` placeholder resolves to "data" (the name of the resource) and is linked as the source of the volume.
+The `${resources.data}` placeholder resolves to "volume.default#<workload>.data" (the uid of the resource) which is converted into outputs, and then into a Docker compose volume.
 
-The volumes are persisted across container starts and stops and can be used for supporting stateful applications.
+The outputs of the volume resource look like:
 
-```console
-$ score-compose init
-$ score-compose generate score.yaml
-...
-$ docker compose up
-[+] Running 3/3
- ✔ Network 05-volume-mounts_default                Created                                                                                                                                                                                                0.1s
- ✔ Volume "hello-world-data-iIlzJ5"                Created                                                                                                                                                                                                0.0s
- ✔ Container 05-volume-mounts-hello-world-first-1  Created                                                                                                                                                                                                0.1s
-Attaching to hello-world-first-1
-...
+```yaml
+type: volume
+source: <generated docker volume name>
 ```
+
+Since this provisions a stateful Docker volume, the state is persisted across restarts and may also be shared between containers.
+
+## Writing a tmpfs provisioner
+
+If the container does not need state to persist across restarts, we can use `tmpfs` volume. This isn't available as a default provisioner but can be easily added to a `.score-compose/0-custom-provisioners.yaml` file:
+
+```yaml
+- uri: template://custom-empty-dir-volume
+  type: emptyDir
+  outputs: |
+    type: tmpfs
+    tmpfs:
+      size: 10000000
+```
+
+This kind of volume cannot be shared across containers.
+
+## Writing a bind provisioner
+
+In some cases you may need to bind mount a volume or file from the host. This could be written as a custom provisioner too!
+
+```yaml
+- uri: template://custom-bind-mount
+  type: host-logs
+  outputs: |
+    type: bind
+    source: /var/log
+    bind:
+      propagation: rprivate
+```
+
+Note that this would usually have a custom type since the typed-provisioner defines what source directory from the host is mounted.

--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -26,6 +26,7 @@
     name: {{ dig "name" .Init.randomVolumeName .State }}
   # Return a source value with the volume name. This can be used in volume resource references now.
   outputs: |
+    type: volume
     source: {{ .State.name }}
   # Add a volume to the docker compose file. We assume our name is unique here. We also apply a label to help ensure
   # that we can track the volume back to the workload and resource that created it.

--- a/internal/command/resources_test.go
+++ b/internal/command/resources_test.go
@@ -123,6 +123,6 @@ volume.default#example.vol
 	t.Run("format template", func(t *testing.T) {
 		stdout, _, err := executeAndResetCommand(context.Background(), rootCmd, []string{"resources", "get-outputs", "volume.default#example.vol", "--format", `{{ . | len }}`})
 		assert.NoError(t, err)
-		assert.Equal(t, "1", stdout)
+		assert.Equal(t, "2", stdout)
 	})
 }

--- a/internal/compose/convert_test.go
+++ b/internal/compose/convert_test.go
@@ -274,7 +274,7 @@ func TestScoreConvert(t *testing.T) {
 				},
 				Resources: map[string]score.Resource{"data": {Type: "thing"}},
 			},
-			Error: errors.New("containers.test.volumes[0].source: resource 'data' is not a volume"),
+			Error: errors.New("containers.test.volumes[0].source: resource 'data' does not exist"),
 		},
 	}
 


### PR DESCRIPTION
This PR changes the way that volumes are provisioned in score-compose. Previously volumes HAD TO be type=volume and return a source value, and were limited to just being persistent docker compose volumes.

This PR now removes the restriction on the type field and just requires that the outputs must match one of the 3 kinds of supported docker compose volume mounts: tmpfs, bind, or persistent volume - and we also support the extended attributes https://docs.docker.com/compose/compose-file/compose-file-v3/#volumes

This also modifies the way the 2-part resource-id placeholder is resolved. `${resources.foo}` will not resolve to `type.class#workload.foo` (the resource uid).