### PR TITLE
feat(provisioners): added mongodb default provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The `score.yaml` specification file can be executed against a _Score Implementat
 | dns          | default | (none)                 | `host`                                                                                                                                                          |
 | route        | default | `host`, `path`, `port` |                                                                                                                                                                 |
 | amqp         | default | (none)                 | `host`, `port`, `vhost`, `username`, `password`                                                                                                                 |
+| mongodb      | default | (none)                 | `host`, `port`, `username`, `password`, `connection`                                                                                                            |
 
 These can be found in the default provisioners file. You are encouraged to write your own provisioners and add them to the `.score-compose` directory (with the `.provisioners.yaml` extension) or contribute them upstream to the [default.provisioners.yaml](internal/command/default.provisioners.yaml) file.
 
@@ -62,6 +63,7 @@ See the [examples](./examples) for more examples of using Score and provisioning
 - [08-service-port-resource](examples/08-service-port-resource) - an example of using the `service-port` resource type to link between workloads
 - [09-dns-and-route](examples/09-dns-and-route) - an example of using the `dns` and `route` resources to route http requests
 - [10-amqp-rabbitmq](examples/10-amqp-rabbitmq) - an example the default `amqp` resource provisioner
+- [11-mongodb-document-database](examples/11-mongodb-document-database) - an example the default `mongodb` resource provisioner
 
 If you're getting started, you can use `score-compose init` to create a basic `score.yaml` file in the current directory along with a `.score-compose/` working directory.
 

--- a/examples/11-mongodb-document-database/README.md
+++ b/examples/11-mongodb-document-database/README.md
@@ -1,0 +1,13 @@
+# 11 - MongoDB document database
+
+As an alternative to the `postgres` and `redis` datastores, there is also a `mongodb` resource provisioner as an example
+of a document database. This uses the official image from https://hub.docker.com/_/mongo.
+
+```
+resources:
+  db:
+    type: mongodb
+```
+
+The provided outputs are `host`, `port`, `username`, `password`, `connection`. The latter is equal to a mongodb 
+connection string like `mongodb://${resources.db.username}:${resources.db.password}@${resources.db.host}:${resources.db.port}/}`.

--- a/examples/11-mongodb-document-database/score.yaml
+++ b/examples/11-mongodb-document-database/score.yaml
@@ -1,0 +1,14 @@
+apiVersion: score.dev/v1b1
+
+metadata:
+  name: hello-world
+
+containers:
+  first:
+    image: nginx
+    variables:
+      CONNECT_1: ${resources.db.connection}
+
+resources:
+  db:
+    type: mongodb

--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -106,7 +106,7 @@
         volume:
           nocopy: true
   info_logs: |
-    - "To connect to redis: \"docker run -it --network {{ .ComposeProjectName }}_default --rm redis redis-cli -h {{ .State.serviceName | squote }} -a {{ .State.password | squote }}\""
+    - "{{.Uid}}: To connect to redis: \"docker run -it --network {{ .ComposeProjectName }}_default --rm redis redis-cli -h {{ .State.serviceName | squote }} -a {{ .State.password | squote }}\""
 
 # The default postgres provisioner adds a postgres instance and then ensures that the required databases are created on
 # startup.
@@ -195,9 +195,9 @@
         source: {{ .MountsDirectory }}/{{ dig .Init.sk "instanceServiceName" "" .Shared }}-db-scripts
         target: /db-scripts
   info_logs: |
-    - "To connect to postgres, enter password {{ .State.password | squote }} at: \"docker run -it --network {{ .ComposeProjectName }}_default --rm postgres:16-alpine psql -h {{ dig .Init.sk "instanceServiceName" "" .Shared }} -U {{ .State.username }} --dbname {{ .State.database }}\""
+    - "{{.Uid}}: To connect to postgres, enter password {{ .State.password | squote }} at: \"docker run -it --network {{ .ComposeProjectName }}_default --rm postgres:16-alpine psql -h {{ dig .Init.sk "instanceServiceName" "" .Shared }} -U {{ .State.username }} --dbname {{ .State.database }}\""
     {{ if ne .Init.publishPort "0" }}
-    - "Or connect your postgres client to \"postgres://{{ .State.username }}:{{ .State.password }}@localhost:{{ .Init.publishPort }}/{{ .State.database }}\""
+    - "{{.Uid}}: Or connect your postgres client to \"postgres://{{ .State.username }}:{{ .State.password }}@localhost:{{ .Init.publishPort }}/{{ .State.database }}\""
     {{ end }}
 
 # This resource provides a minio based S3 bucket with AWS-style credentials.
@@ -289,9 +289,9 @@
         source: {{ .MountsDirectory }}/{{ dig .Init.sk "instanceServiceName" "" .Shared }}-setup-scripts
         target: /setup-scripts
   info_logs: |
-    - "To connect with a minio client: use the myminio alias at \"docker run -it --network {{ .ComposeProjectName }}_default --rm --entrypoint /bin/bash quay.io/minio/minio -c 'mc alias set myminio http://{{ dig .Init.sk "instanceServiceName" "" .Shared }}:9000 {{ dig .Init.sk "instanceAccessKeyId" "" .Shared }} {{ dig .Init.sk "instanceSecretKey" "" .Shared }}; bash'\""
+    - "{{.Uid}}: To connect with a minio client: use the myminio alias at \"docker run -it --network {{ .ComposeProjectName }}_default --rm --entrypoint /bin/bash quay.io/minio/minio -c 'mc alias set myminio http://{{ dig .Init.sk "instanceServiceName" "" .Shared }}:9000 {{ dig .Init.sk "instanceAccessKeyId" "" .Shared }} {{ dig .Init.sk "instanceSecretKey" "" .Shared }}; bash'\""
     {{ if ne .Init.publishPort 0 }}
-    - "Or enter {{ dig .Init.sk "instanceUsername" "" .Shared }} / {{ dig .Init.sk "instancePassword" "" .Shared }} at https://localhost:{{ .Init.publishPort }}"
+    - "{{.Uid}}: Or enter {{ dig .Init.sk "instanceUsername" "" .Shared }} / {{ dig .Init.sk "instancePassword" "" .Shared }} at https://localhost:{{ .Init.publishPort }}"
     {{ end }}
 
 
@@ -376,7 +376,7 @@
         target: /db-scripts
   info_logs: |
     {{ if ne .Init.publishManagementPort 0 }}
-    - "Browse the rabbitmq UI at \"http://localhost:{{ .Init.publishManagementPort }}\""
+    - "{{.Uid}}: Browse the rabbitmq UI at \"http://localhost:{{ .Init.publishManagementPort }}\""
     {{ end }}
 # The default dns provisioner just outputs localhost as the hostname every time.
 # This is because without actual control of a dns resolver we can't do any accurate routing on any other name. This
@@ -486,3 +486,51 @@
   info_logs: |
     {{ $p := (dig .Init.sk "instancePort" 0 .Shared) }}
     - "{{.Uid}}: To connect to this route, http://{{ .Params.host }}:{{ $p }}{{ .Params.path }} (make sure {{ .Params.host }} resolves to localhost)"
+
+# The default mongodb provisioner adds a mongodb service to the project which returns a host, port, username, and password, and connection string.
+- uri: template://default-provisioners/mongodb
+  type: mongodb
+  init: |
+    port: 27017
+    randomServiceName: mongo-{{ randAlphaNum 6 }}
+    randomUsername: user-{{ randAlpha 8 }}
+    randomPassword: {{ randAlphaNum 16 | quote }}
+  state: |
+    serviceName: {{ dig "serviceName" .Init.randomServiceName .State | quote }}
+    username: {{ dig "username" .Init.randomUsername .State | quote }}
+    password: {{ dig "password" .Init.randomPassword .State | quote }}
+  outputs: |
+    host: {{ .State.serviceName }}
+    port: {{ .Init.port }}
+    username: {{ .State.username | quote }}
+    password: {{ .State.password | quote }}
+    connection: "mongodb://{{ .State.username }}:{{ .State.password }}@{{ .State.serviceName }}:{{ .Init.port }}/"
+  volumes: |
+    {{ .State.serviceName }}-data:
+      name: {{ .State.serviceName }}-data
+      driver: local
+      labels:
+        dev.score.compose.res.uid: {{ .Uid }}
+  services: |
+    {{ .State.serviceName }}:
+      labels:
+        dev.score.compose.res.uid: {{ .Uid }}
+      image: mongo:7
+      restart: always
+      environment:
+        MONGO_INITDB_ROOT_USERNAME: {{ .State.username | quote }}
+        MONGO_INITDB_ROOT_PASSWORD: {{ .State.password | quote }}
+      healthcheck:
+        test: ["CMD-SHELL", "echo 'db.runCommand(\"ping\").ok' | mongosh -u $$MONGO_INITDB_ROOT_USERNAME -p $$MONGO_INITDB_ROOT_PASSWORD"]
+        interval: 2s
+        timeout: 5s
+        retries: 5
+        start_period: 10s
+      volumes:
+      - type: volume
+        source: {{ .State.serviceName }}-data
+        target: /data/db
+        volume:
+          nocopy: true
+  info_logs: |
+    - "{{.Uid}}: To connect to mongo: \"docker exec -ti {{ .ComposeProjectName }}-{{ .State.serviceName }}-1 mongosh -u {{ .State.username }} -p {{ .State.password }}\""

--- a/internal/command/generate_examples_test.go
+++ b/internal/command/generate_examples_test.go
@@ -180,6 +180,10 @@ services:
 			subDir: "10-amqp-rabbitmq",
 			adds:   []string{"score.yaml"},
 		},
+		{
+			subDir: "11-mongodb-document-database",
+			adds:   []string{"score.yaml"},
+		},
 	} {
 		t.Run(tc.subDir, func(t *testing.T) {
 			oldReader := rand.Reader


### PR DESCRIPTION
We have datastore implementations for postgres and redis, and this PR introduces a new provisioner for a document DB: mongodb.

This provisions a single mongo container with persistent data and healthcheck. An exec command is provided to support working with the data.

generate:

```
$ score-compose generate score.yaml
INFO: Loaded state directory with docker compose project '11-mongodb-document-database'
INFO: Validated workload 'hello-world'
INFO: Successfully loaded 9 resource provisioners
INFO: mongodb.default#hello-world.db: To connect to mongo: "docker exec -ti 11-mongodb-document-database-mongo-JTyNG0-1 mongosh -u user-HCEtQlbs -p XtCgk7PWMqpORIsn"
INFO: Provisioned 1 resources
INFO: Converting workload 'hello-world' to Docker compose
```

And docker compose up returns:

```
[+] Running 3/4
 ⠋ Volume "mongo-G9ssoa-data"                                   Created                                                                                                                                                                                                                    6.0s
 ✔ Container 11-mongodb-document-database-mongo-G9ssoa-1        Healthy                                                                                                                                                                                                                    5.4s
 ✔ Container 11-mongodb-document-database-wait-for-resources-1  Started                                                                                                                                                                                                                    5.6s
 ✔ Container 11-mongodb-document-database-hello-world-first-1   Started
```

Our hello world container contains the connection string

```
$ docker exec -ti 4946f4727f28 sh -c 'echo $CONNECT_1'
mongodb://user-SUGtvhox:zvrTunGR4fjqJASR@mongo-G9ssoa:27017/
```

And running the exec command returns:

```
Current Mongosh Log ID:	6627c9a9767c46ab553b9273
Connecting to:		mongodb://<credentials>@127.0.0.1:27017/?directConnection=true&serverSelectionTimeoutMS=2000&appName=mongosh+2.2.4
Using MongoDB:		7.0.8
Using Mongosh:		2.2.4

For mongosh info see: https://docs.mongodb.com/mongodb-shell/

test> show databases
admin   100.00 KiB
config   12.00 KiB
local    72.00 KiB
```

Good stuff 🎉 
