### PR TITLE
fix: re-add contents:write permissions to release ci

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: release
 on: [push]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   
@@ -48,7 +48,9 @@ jobs:
       - test
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # must be able to setup a release
+      contents: write
+      # must be able to push a package
       packages: write
     steps:
       -


### PR DESCRIPTION
Release 0.14.0 failed due to missing permissions.