### PR TITLE
feat(route-provisioner): increased client body size and added nginx snippet annotations

### DIFF
--- a/examples/09-dns-and-route/README.md
+++ b/examples/09-dns-and-route/README.md
@@ -40,7 +40,7 @@ This adds an additional nginx service to the compose file which contains an HTTP
 
 By default, this listens on http://localhost:8080 and in the example will route paths like `/my/fizz/path`, `/my/buzz/path/thing`. The port 8080 unfortunately cannot be changed without modifying the provisioner in the default provisioners file after running `score-compose init`.
 
-By default, this uses a `Prefix` route matching type so `/` can match `/any/request/path` but you can add a `score-compose.score.dev/route-provisioner-path-type: Exact` annotation to a Route to restrict this behavior to just an exact match.
+By default, this uses a `Prefix` route matching type so `/` can match `/any/request/path` but you can add a `compose.score.dev/route-provisioner-path-type: Exact` annotation to a Route to restrict this behavior to just an exact match.
 
 When running this compose project, we can test these routes using curl (in this instance the generated dns name was `dnsmntq6e`):
 
@@ -49,6 +49,20 @@ $ curl http://dnsmntq6e.localhost:8080/my/fizz/path/
 fizz
 $ curl http://dnsmntq6e.localhost:8080/my/buzz/path/
 buzz
+```
+
+## Adjusting Nginx configuration
+
+The default `route` provisioner generates an nginx config file. If you need to adjust any of the settings or send particular headers, you can use the following snippet annotations.
+
+- `compose.score.dev/route-provisioner-server-snippet` - indents and then adds the lines in the "server" block of nginx.
+- `compose.score.dev/route-provisioner-location-snippet` - indents and then adds the lines to every "location" block of nginx.
+
+It is recommended not to include these directly in your Score file and instead add them using the `--overrides-file` or `--override-property` flags when calling `score-compose generate`:
+
+```
+$ score-compose generate score.yaml \
+    --override-property 'resources.route.metadata.annotations.compose\.score\.dev/route-provisioner-server-snippet="client_max_body_size  20m;"'
 ```
 
 ## Fixed DNS names

--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -403,6 +403,7 @@
     {{ if not $ports }}{{ fail "no service ports exist" }}{{ end }}
     {{ $port := index $ports (print .Params.port) }}
     {{ if not $port.TargetPort }}{{ fail "params.port is not a named service port" }}{{ end }}
+
   shared: |
     {{ .Init.sk }}:
       instancePort: {{ dig .Init.sk "instancePort" 8080 .Shared }}
@@ -414,7 +415,7 @@
       {{ $target := (printf "%s:%d" $targetHost $targetPort) }}
       {{ $hBefore := dig .Init.sk "hosts" (dict) .Shared }}
       {{ $rBefore := dig .Params.host (dict) $hBefore }}
-      {{ $pathType := dig "score-compose.score.dev/route-provisioner-path-type" "Prefix" (dig "annotations" (dict) (.Metadata | default (dict))) }}
+      {{ $pathType := dig "compose.score.dev/route-provisioner-path-type" "Prefix" (dig "annotations" (dict) (.Metadata | default (dict))) }}
       {{ $inner := dict "path" .Params.path "target" $target "port" $targetPort "path_type" $pathType }}
       {{ $rAfter := (merge $rBefore (dict .Uid $inner)) }}
       {{ $hAfter := (merge $hBefore (dict .Params.host $rAfter)) }}
@@ -444,7 +445,9 @@
           proxy_read_timeout                      60s;
           proxy_buffers                           16 4k;
           proxy_buffer_size                       2k;
-
+          client_max_body_size                    10m;
+      {{ dig "compose.score.dev/route-provisioner-server-snippet" "" (dig "annotations" (dict) ($.Metadata | default (dict))) | indent 4 }}
+        
           location = /favicon.ico {
             return 204;
             access_log     off;
@@ -456,13 +459,15 @@
           location ~ ^{{ index $v "path" }}$ {
             set $backend {{ index $v "target" }};
             proxy_pass http://$backend;
+      {{ dig "compose.score.dev/route-provisioner-location-snippet" "" (dig "annotations" (dict) ($.Metadata | default (dict))) | indent 6 }}
           }
 
-          # The prefix match variants are included by default but can be excluded via 'score-compose.score.dev/route-provisioner-path-type' annotation
+          # The prefix match variants are included by default but can be excluded via 'compose.score.dev/route-provisioner-path-type' annotation
           {{ if eq (index $v "path_type") "Prefix" }}
           location ~ ^{{ index $v "path" | trimSuffix "/" }}/.* {
             set $backend {{ index $v "target" }};
             proxy_pass http://$backend;
+      {{ dig "compose.score.dev/route-provisioner-location-snippet" "" (dig "annotations" (dict) ($.Metadata | default (dict))) | indent 6 }}
           }
           {{ end }}
           {{ end }}

--- a/internal/command/generate_test.go
+++ b/internal/command/generate_test.go
@@ -875,7 +875,7 @@ resources:
     type: route
     metadata:
       annotations:
-        score-compose.score.dev/route-provisioner-path-type: Exact
+        compose.score.dev/route-provisioner-path-type: Exact
     params:
       host: localhost2
       path: /third


### PR DESCRIPTION
Increased the max client body size default from 1m to 10m. It's too easy these days to hit the max. Also added support for nginx config snippets just like the Kubernetes ingress does.
