### PR TITLE
feat: added kafka-topic provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The `score.yaml` specification file can be executed against a _Score Implementat
 | route        | default | `host`, `path`, `port` |                                                                                                                                                                 |
 | amqp         | default | (none)                 | `host`, `port`, `vhost`, `username`, `password`                                                                                                                 |
 | mongodb      | default | (none)                 | `host`, `port`, `username`, `password`, `connection`                                                                                                            |
+| kafka-topic  | default | (none)                 | `host`, `port`, `name`, `num_partitions`                                                                                                                        |
 
 These can be found in the default provisioners file. You are encouraged to write your own provisioners and add them to the `.score-compose` directory (with the `.provisioners.yaml` extension) or contribute them upstream to the [default.provisioners.yaml](internal/command/default.provisioners.yaml) file.
 
@@ -65,6 +66,8 @@ See the [examples](./examples) for more examples of using Score and provisioning
 - [09-dns-and-route](examples/09-dns-and-route) - an example of using the `dns` and `route` resources to route http requests
 - [10-amqp-rabbitmq](examples/10-amqp-rabbitmq) - an example the default `amqp` resource provisioner
 - [11-mongodb-document-database](examples/11-mongodb-document-database) - an example the default `mongodb` resource provisioner
+- [12-mysql-database](examples/12-mysql-database) - an example of the `mysql` resource provisioner
+- [13-kafka-topic](examples/13-kafka-topic) - an example of the default `kafka-topic` resource provisioner
 
 If you're getting started, you can use `score-compose init` to create a basic `score.yaml` file in the current directory along with a `.score-compose/` working directory.
 

--- a/examples/13-kafka-topic/README.md
+++ b/examples/13-kafka-topic/README.md
@@ -1,0 +1,16 @@
+# 13 - Kafka Topic
+
+The `kafka-topic` provisioner ensures that there is a Kafka topic with 3 partitions available in Docker.
+
+See [score.yaml](score.yaml) as an example. This app launches a Redpanda Console configured for the given Kafka broker. A Score dns and route resource are used to expose it locally outside of Docker.
+
+This provisioner also supports an annotation for exposing the broker port for access from outside Docker:
+
+```yaml
+resources:
+  bus:
+    type: kafka-topic
+    metadata:
+      annotations:
+        "compose.score.dev/publish-port": "9092"
+```

--- a/examples/13-kafka-topic/score.yaml
+++ b/examples/13-kafka-topic/score.yaml
@@ -1,0 +1,29 @@
+apiVersion: score.dev/v1b1
+
+metadata:
+  name: hello-world
+
+containers:
+  main:
+    image: docker.redpanda.com/redpandadata/console:latest
+    variables:
+      KAFKA_BROKERS: "${resources.bus.host}:${resources.bus.port}"
+      _KAFKA_TOPIC: ${resources.bus.name}
+      _KAFKA_PARTITIONS: ${resources.bus.num_partitions}
+
+service:
+  ports:
+    web:
+      port: 8080
+
+resources:
+  bus:
+    type: kafka-topic
+  dns:
+    type: dns
+  route:
+    type: route
+    params:
+      path: /
+      host: ${resources.dns.host}
+      port: web

--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -619,3 +619,59 @@
     - "{{.Uid}}: Or connect your mysql client to \"
     mysql://{{ .State.username }}:{{ .State.password }}@{{ dig .Init.sk "instanceServiceName" "" .Shared }}:{{ .Init.publishPort }}/{{ .State.database }}\""
     {{ end }}
+
+- uri: template://default-provisioners/kafka-topic
+  type: kafka-topic
+  init: |
+    brokerPort: 9092
+    ctrlPort: 9093
+  state: |
+    topic: {{ dig "topic" (print "topic-" (randAlphaNum 6)) .State | quote }}
+  shared: |
+    shared_kafka_instance_name: {{ dig "shared_kafka_instance_name" (print "kafka-" (randAlphaNum 6)) .Shared | quote }}
+  services: |
+    {{ .Shared.shared_kafka_instance_name }}:
+      image: bitnami/kafka:latest
+      restart: always
+      environment:
+        KAFKA_CFG_NODE_ID: "0"
+        KAFKA_CFG_PROCESS_ROLES: controller,broker
+        KAFKA_CFG_LISTENERS: "PLAINTEXT://:{{ .Init.brokerPort }},CONTROLLER://:{{ .Init.ctrlPort }}"
+        KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+        KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "0@{{ .Shared.shared_kafka_instance_name }}:{{ .Init.ctrlPort }}"
+        KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+        KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: "false"
+      healthcheck:
+        test: ["CMD", "kafka-topics.sh", "--list", "--bootstrap-server=localhost:{{ .Init.brokerPort }}"]
+        interval: 2s
+        timeout: 2s
+        retries: 10
+      {{ $publishPort := (dig "annotations" "compose.score.dev/publish-port" "0" .Metadata | atoi) }}
+      {{ if ne $publishPort 0 }}
+      ports:
+      - target: {{ .Init.brokerPort }}
+        published: {{ $publishPort }}
+      {{ end }}
+      volumes:
+      - type: volume
+        source: {{ .Shared.shared_kafka_instance_name }}-data
+        target: /bitnami/kafka
+    {{ .State.topic }}-init:
+      image: bitnami/kafka:latest
+      entrypoint: ["/bin/sh"]
+      command: ["-c", "kafka-topics.sh --topic={{.State.topic}} --bootstrap-server=localhost:{{ .Init.brokerPort }} --describe || kafka-topics.sh --topic={{.State.topic}} --bootstrap-server=localhost:{{ .Init.brokerPort }} --create --partitions=3"]
+      network_mode: "service:{{ .Shared.shared_kafka_instance_name }}"
+      labels:
+        dev.score.compose.labels.is-init-container: "true"
+      depends_on:
+        {{ .Shared.shared_kafka_instance_name }}:
+          condition: service_healthy
+          restart: true
+  volumes: |
+    {{ .Shared.shared_kafka_instance_name }}-data:
+      driver: local
+  outputs: |
+    host: {{ .Shared.shared_kafka_instance_name }}
+    port: "{{ .Init.brokerPort }}"
+    name: {{ .State.topic }}
+    num_partitions: 3

--- a/internal/command/generate_examples_test.go
+++ b/internal/command/generate_examples_test.go
@@ -205,6 +205,14 @@ services:
 			subDir: "11-mongodb-document-database",
 			adds:   []string{"score.yaml"},
 		},
+		{
+			subDir: "12-mysql-database",
+			adds:   []string{"score.yaml"},
+		},
+		{
+			subDir: "13-kafka-topic",
+			adds:   []string{"score.yaml"},
+		},
 	} {
 		t.Run(tc.subDir, func(t *testing.T) {
 			oldReader := rand.Reader


### PR DESCRIPTION
See the newly added example in examples/13-kafka-topic. This provisions a 3-partition kafka topic on a random host.

```
$ go run ../../cmd/score-compose resources list
dns.default#hello-world.dns
kafka-topic.default#hello-world.bus
route.default#hello-world.route

$ go run ../../cmd/score-compose resources get-outputs 'kafka-topic.default#hello-world.bus'
{"host":"kafka-e9KQfd","name":"topic-lTppsn","num_partitions":3,"port":"9092"}
```

You can see in the example screenshot that the redpanda console can connect to it successfully:

![Screenshot 2024-06-05 at 16 36 41](https://github.com/score-spec/score-compose/assets/1651305/f6fba829-7cd5-4ae4-b2bb-d035f6737037)

Fixes #149 