### PR TITLE
feat: hide deprecated run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Global Flags:
   -v, --verbose count   Increase log verbosity and detail by specifying this flag one or more times
 ```
 
-**NOTE**: The `score-compose run` command still exists but should be considered deprecated as it does not support resource provisioning.
+**NOTE**: The `score-compose run` command still exists but is hidden and should be considered deprecated as it does not support resource provisioning.
 
 ## ![Get involved](docs/images/get-involved.svg) Get involved
 

--- a/internal/command/root_test.go
+++ b/internal/command/root_test.go
@@ -38,7 +38,7 @@ Available Commands:
   help        Help about any command
   init        Initialise a new score-compose project with local state directory and score file
   resources   Subcommands related to provisioned resources
-  run         Translate the SCORE file to docker-compose configuration
+  run         (Deprecated) Translate the SCORE file to docker-compose configuration
 
 Flags:
   -h, --help            help for score-compose

--- a/internal/command/root_test.go
+++ b/internal/command/root_test.go
@@ -38,7 +38,6 @@ Available Commands:
   help        Help about any command
   init        Initialise a new score-compose project with local state directory and score file
   resources   Subcommands related to provisioned resources
-  run         (Deprecated) Translate the SCORE file to docker-compose configuration
 
 Flags:
   -h, --help            help for score-compose

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -76,7 +76,8 @@ func init() {
 var runCmd = &cobra.Command{
 	Use:   "run [--file=score.yaml] [--output=compose.yaml]",
 	Args:  cobra.NoArgs,
-	Short: "Translate the SCORE file to docker-compose configuration",
+	Short: "(Deprecated) Translate the SCORE file to docker-compose configuration",
+	Hidden: true,
 	RunE:  run,
 	// don't print the errors - we print these ourselves in main()
 	SilenceErrors: true,

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -69,7 +69,7 @@ func executeAndResetCommand(ctx context.Context, cmd *cobra.Command, args []stri
 func TestRunHelp(t *testing.T) {
 	stdout, stderr, err := executeAndResetCommand(context.Background(), rootCmd, []string{"run", "--help"})
 	assert.NoError(t, err)
-	assert.Equal(t, `Translate the SCORE file to docker-compose configuration
+	assert.Equal(t, `(Deprecated) Translate the SCORE file to docker-compose configuration
 
 Usage:
   score-compose run [--file=score.yaml] [--output=compose.yaml] [flags]


### PR DESCRIPTION
The run command is still accessible  and can still be used in CI if needed, but it is not removed from the documented behavior.
