### PR TITLE
fix: ensure resource output template has a newline

### DIFF
--- a/internal/command/resources.go
+++ b/internal/command/resources.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
@@ -95,6 +96,10 @@ be returned as json.
 				case "yaml":
 					return yaml.NewEncoder(cmd.OutOrStdout()).Encode(outputs)
 				default:
+					// ensure there is a new line at the end if one is not already present
+					if !strings.HasSuffix(formatValue, "\n") {
+						formatValue += "\n"
+					}
 					prepared, err := template.New("").Funcs(sprig.FuncMap()).Parse(formatValue)
 					if err != nil {
 						return fmt.Errorf("failed to parse format template: %w", err)

--- a/internal/command/resources_test.go
+++ b/internal/command/resources_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -111,6 +112,7 @@ volume.default#example.vol
 		assert.NoError(t, err)
 		var out map[string]interface{}
 		assert.NoError(t, json.Unmarshal([]byte(stdout), &out))
+		assert.True(t, strings.HasSuffix(stdout, "\n"))
 	})
 
 	t.Run("format yaml", func(t *testing.T) {
@@ -118,11 +120,18 @@ volume.default#example.vol
 		assert.NoError(t, err)
 		var out map[string]interface{}
 		assert.NoError(t, yaml.Unmarshal([]byte(stdout), &out))
+		assert.True(t, strings.HasSuffix(stdout, "\n"))
 	})
 
 	t.Run("format template", func(t *testing.T) {
 		stdout, _, err := executeAndResetCommand(context.Background(), rootCmd, []string{"resources", "get-outputs", "volume.default#example.vol", "--format", `{{ . | len }}`})
 		assert.NoError(t, err)
-		assert.Equal(t, "2", stdout)
+		assert.Equal(t, "2\n", stdout)
+	})
+
+	t.Run("format template with newline", func(t *testing.T) {
+		stdout, _, err := executeAndResetCommand(context.Background(), rootCmd, []string{"resources", "get-outputs", "volume.default#example.vol", "--format", "{{ . | len }}\n"})
+		assert.NoError(t, err)
+		assert.Equal(t, "2\n", stdout)
 	})
 }


### PR DESCRIPTION
See #160.

Ensure there's a newline so that output in a terminal makes sense and doesn't mess up printing.
