### PR TITLE
fix: improve depends-on condition for wait-for-resources

### DIFF
--- a/internal/command/generate.go
+++ b/internal/command/generate.go
@@ -244,7 +244,7 @@ arguments.
 					if service.DependsOn == nil {
 						service.DependsOn = make(types.DependsOnConfig)
 					}
-					service.DependsOn[waitServiceName] = types.ServiceDependency{Condition: "service_started"}
+					service.DependsOn[waitServiceName] = types.ServiceDependency{Condition: "service_completed_successfully", Required: true}
 				}
 				superProject.Services[serviceName] = service
 			}

--- a/internal/command/generate_test.go
+++ b/internal/command/generate_test.go
@@ -562,8 +562,8 @@ services:
             compose.score.dev/workload-name: example
         depends_on:
             wait-for-resources:
-                condition: service_started
-                required: false
+                condition: service_completed_successfully
+                required: true
         hostname: example
         image: foo
     generic_service:
@@ -663,8 +663,8 @@ services:
             compose.score.dev/workload-name: example
         depends_on:
             wait-for-resources:
-                condition: service_started
-                required: false
+                condition: service_completed_successfully
+                required: true
         hostname: example
         image: busybox
     foo-service:


### PR DESCRIPTION
I found an interesting condition with the wait-for-resources service when doing a command like `docker compose up <some-service> --wait`:

```
$ docker compose up hello-world-first --wait
[+] Running 3/3
 ✔ Container 12-mysql-database-mysql-8MjJEo-1        Healthy                                                                                                                                                                                                                    0.0s 
 ✔ Container 12-mysql-database-wait-for-resources-1  Created                                                                                                                                                                                                                    0.0s 
 ✔ Container 12-mysql-database-hello-world-first-1   Healthy                                                                                                                                                                                                                    0.2s 
container 12-mysql-database-wait-for-resources-1 exited (0)
$ echo $?
1
```

Note the non-zero exit code!

So this PR fixes it and moves to a more reasonable code.

```
$ docker compose up hello-world-first --wait
[+] Running 3/3
 ✔ Container 12-mysql-database-mysql-8MjJEo-1        Healthy                                                                                                                                                                                                                    0.0s 
 ✔ Container 12-mysql-database-wait-for-resources-1  Exited                                                                                                                                                                                                                     0.0s 
 ✔ Container 12-mysql-database-hello-world-first-1   Healthy    
$ echo $?
0
```