### PR TITLE
fix: increase healthcheck retries

### DIFF
--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -163,7 +163,7 @@
         test: ["CMD", "pg_isready", "-U", "postgres"]
         interval: 2s
         timeout: 2s
-        retries: 10
+        retries: 15
     {{ dig .Init.sk "instanceServiceName" "" .Shared }}-init:
       image: postgres:16-alpine
       entrypoint: ["/bin/sh"]
@@ -254,7 +254,7 @@
         test: ["CMD-SHELL", "mc alias set myminio http://localhost:9000 {{ dig .Init.sk "instanceUsername" "" .Shared }} {{ dig .Init.sk "instancePassword" "" .Shared }}"]
         interval: 2s
         timeout: 2s
-        retries: 10
+        retries: 15
       environment:
         MINIO_ROOT_USER: {{ dig .Init.sk "instanceUsername" "" .Shared | quote }}
         MINIO_ROOT_PASSWORD: {{ dig .Init.sk "instancePassword" "" .Shared | quote }}
@@ -341,7 +341,7 @@
         test: ["CMD-SHELL", "rabbitmq-diagnostics -q check_port_connectivity"]
         interval: 2s
         timeout: 5s
-        retries: 5
+        retries: 15
     {{ dig .Init.sk "instanceServiceName" "" .Shared }}-init:
       image: rabbitmq:3-management-alpine
       entrypoint: ["/bin/sh"]
@@ -519,7 +519,7 @@
         test: ["CMD-SHELL", "echo 'db.runCommand(\"ping\").ok' | mongosh -u $$MONGO_INITDB_ROOT_USERNAME -p $$MONGO_INITDB_ROOT_PASSWORD"]
         interval: 2s
         timeout: 5s
-        retries: 5
+        retries: 15
         start_period: 10s
       volumes:
       - type: volume


### PR DESCRIPTION
I noticed while working with the rabbitmq provisioner that sometimes the container errors while waiting for the service to come up. This is usually when the system is constrained by some other load like a video call.

When looking at the logs of the process I can see that it's not ready by the time the healthcheck gives up and this problem can be resolved by increasing the timeouts. I've done this in this PR to increase most services up to approximately 30s of retry attempts.
