### PR TITLE
fix: added validation error when --image or --build are used with multiple score files

### DIFF
--- a/internal/command/generate.go
+++ b/internal/command/generate.go
@@ -97,6 +97,14 @@ arguments.
 		}
 		slog.Debug("Input Workload names", "names", workloadNames)
 
+		// Forbid --image and --build when multiple score files are provided
+		if v, _ := cmd.Flags().GetString(generateCmdImageFlag); v != "" && len(workloadNames) > 1 {
+			return fmt.Errorf("--%s cannot be used when multiple score files are provided", generateCmdImageFlag)
+		}
+		if v, _ := cmd.Flags().GetStringArray(generateCmdBuildFlag); len(v) > 0 && len(workloadNames) > 1 {
+			return fmt.Errorf("--%s cannot be used when multiple score files are provided", generateCmdBuildFlag)
+		}
+
 		// Now read and apply any overrides files to the score files
 		if v, _ := cmd.Flags().GetString(generateCmdOverridesFileFlag); v != "" {
 			if len(workloadNames) == 0 {

--- a/internal/command/generate_test.go
+++ b/internal/command/generate_test.go
@@ -1359,3 +1359,59 @@ resources:
 		})
 	}
 }
+
+func TestGenerateMultipleSpecsWithImage(t *testing.T) {
+	td := changeToTempDir(t)
+	stdout, _, err := executeAndResetCommand(context.Background(), rootCmd, []string{"init"})
+	assert.NoError(t, err)
+	assert.Equal(t, "", stdout)
+	assert.NoError(t, os.WriteFile(filepath.Join(td, "scoreA.yaml"), []byte(`
+apiVersion: score.dev/v1b1
+metadata:
+  name: example-a
+containers:
+  hello:
+    image: foo
+`), 0644))
+	assert.NoError(t, os.WriteFile(filepath.Join(td, "scoreB.yaml"), []byte(`
+apiVersion: score.dev/v1b1
+metadata:
+  name: example-b
+containers:
+  hello:
+    image: foo
+`), 0644))
+	stdout, _, err = executeAndResetCommand(context.Background(), rootCmd, []string{
+		"generate", "--image", "nginx:latest", "scoreA.yaml", "scoreB.yaml",
+	})
+	assert.EqualError(t, err, "--image cannot be used when multiple score files are provided")
+	assert.Equal(t, "", stdout)
+}
+
+func TestGenerateMultipleSpecsWithBuild(t *testing.T) {
+	td := changeToTempDir(t)
+	stdout, _, err := executeAndResetCommand(context.Background(), rootCmd, []string{"init"})
+	assert.NoError(t, err)
+	assert.Equal(t, "", stdout)
+	assert.NoError(t, os.WriteFile(filepath.Join(td, "scoreA.yaml"), []byte(`
+apiVersion: score.dev/v1b1
+metadata:
+  name: example-a
+containers:
+  hello:
+    image: foo
+`), 0644))
+	assert.NoError(t, os.WriteFile(filepath.Join(td, "scoreB.yaml"), []byte(`
+apiVersion: score.dev/v1b1
+metadata:
+  name: example-b
+containers:
+  hello:
+    image: foo
+`), 0644))
+	stdout, _, err = executeAndResetCommand(context.Background(), rootCmd, []string{
+		"generate", "--build", "foo=.", "scoreA.yaml", "scoreB.yaml",
+	})
+	assert.EqualError(t, err, "--build cannot be used when multiple score files are provided")
+	assert.Equal(t, "", stdout)
+}


### PR DESCRIPTION
See #173. The initial request was to support this with a workload name clarifier but after discussion we decided that we want to push folks away from a "mega command" and towards a more iteration-based approach. So when users hit this error, they should break their command into separate invocations.

