### PR TITLE
Update default.provisioners.yaml - `nginx:1-alpine`

### DIFF
--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -468,7 +468,7 @@
   services: |
     {{ $p := (dig .Init.sk "instancePort" 0 .Shared) }}
     {{ dig .Init.sk "instanceServiceName" "" .Shared }}:
-      image: "nginx:1"
+      image: "nginx:1-alpine"
       restart: always
       ports:
         - published: {{ $p }}


### PR DESCRIPTION
Lighter `nginx` container image for the default `route` provisioner.

Saving 144.8MB on disk:
```
REPOSITORY                                              TAG                   IMAGE ID       CREATED        SIZE
nginx                                                   1-alpine              c7b4f26a7d93   4 weeks ago    43.2MB
nginx                                                   1                     39286ab8a5e1   4 weeks ago    188MB
```