### PR TITLE
Update release.yaml - update GH actions versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@latest
         with:
           fetch-depth: 0
       -
@@ -20,7 +20,7 @@ jobs:
         run: git fetch --force --tags
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@latest
         with:
           go-version-file: 'go.mod'
       -
@@ -28,7 +28,7 @@ jobs:
         run: go test ./... -cover -race
       -
         name: Build binary
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@latest
         with:
           distribution: goreleaser
           version: '~> v2'
@@ -41,7 +41,7 @@ jobs:
         run: addlicense -l apache -check -v -ignore '**/*.yaml' -c Humanitec ./cmd ./internal/
       -
         name: Build docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@latest
         with:
           context: .
           push: false
@@ -55,7 +55,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@latest
         with:
           fetch-depth: 0
       -
@@ -63,12 +63,12 @@ jobs:
         run: git fetch --force --tags
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@latest
         with:
           go-version-file: 'go.mod'
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@latest
         with:
           distribution: goreleaser
           version: '~> v2'
@@ -78,17 +78,17 @@ jobs:
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@latest
       -
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@latest
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@latest
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Fixing deprecation warning:
```
The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, actions/setup-go@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

Proposing to use `latest` for all the GH actions, to minimize burden in maintenance.