### PR TITLE
Added oci example in `score-compose init --help`

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -226,11 +226,12 @@ func init() {
 	initCmd.Flags().StringP(initCmdFileProjectFlag, "p", "", "Set the name of the docker compose project (defaults to the current directory name)")
 	initCmd.Flags().Bool(initCmdFileNoSampleFlag, false, "Disable generation of the sample score file")
 	initCmd.Flags().StringArray(initCmdProvisionerFlag, nil, "Provisioner files to install. May be specified multiple times. Supports:\n"+
-		"- HTTP:      http://host/file\n"+
-		"- HTTPS:     https://host/file\n"+
-		"- Git (SSH): git-ssh://git@host/repo.git/file\n"+
-		"- Git (HTTPS): git-https://host/repo.git/file\n"+
-		"- OCI:       oci://[registry/][namespace/]repository[:tag|@digest]")
+		"- HTTP        : http://host/file\n"+
+		"- HTTPS       : https://host/file\n"+
+		"- Git (SSH)   : git-ssh://git@host/repo.git/file\n"+
+		"- Git (HTTPS) : git-https://host/repo.git/file\n"+
+		"- OCI         : oci://[registry/][namespace/]repository[:tag|@digest]")
+
 	rootCmd.AddCommand(initCmd)
 }
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -225,8 +225,12 @@ func init() {
 	initCmd.Flags().StringP(initCmdFileFlag, "f", scoreFileDefault, "The score file to initialize")
 	initCmd.Flags().StringP(initCmdFileProjectFlag, "p", "", "Set the name of the docker compose project (defaults to the current directory name)")
 	initCmd.Flags().Bool(initCmdFileNoSampleFlag, false, "Disable generation of the sample score file")
-	initCmd.Flags().StringArray(initCmdProvisionerFlag, nil, "A provisioners file to install. May be specified multiple times. Supports http://host/file, https://host/file, git-ssh://git@host/repo.git/file, and  git-https://host/repo.git/file formats.")
-
+	initCmd.Flags().StringArray(initCmdProvisionerFlag, nil, "Provisioner files to install. May be specified multiple times. Supports:\n"+
+		"- HTTP:      http://host/file\n"+
+		"- HTTPS:     https://host/file\n"+
+		"- Git (SSH): git-ssh://git@host/repo.git/file\n"+
+		"- Git (HTTPS): git-https://host/repo.git/file\n"+
+		"- OCI:       oci://[registry/][namespace/]repository[:tag|@digest]")
 	rootCmd.AddCommand(initCmd)
 }
 

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -67,7 +67,12 @@ Flags:
   -h, --help                       help for init
       --no-sample                  Disable generation of the sample score file
   -p, --project string             Set the name of the docker compose project (defaults to the current directory name)
-      --provisioners stringArray   A provisioners file to install. May be specified multiple times. Supports http://host/file, https://host/file, git-ssh://git@host/repo.git/file, and  git-https://host/repo.git/file formats.
+      --provisioners stringArray   Provisioner files to install. May be specified multiple times. Supports:
+                                   - HTTP        : http://host/file
+                                   - HTTPS       : https://host/file
+                                   - Git (SSH)   : git-ssh://git@host/repo.git/file
+                                   - Git (HTTPS) : git-https://host/repo.git/file
+                                   - OCI         : oci://[registry/][namespace/]repository[:tag|@digest]
 
 Global Flags:
       --quiet           Mute any logging output


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR add the oci example to `init.go` and also a updated output format. #178 
#### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
By adding the oci example it help people to understand the new feat.
<img width="678" alt="Screenshot 2024-10-20 at 1 00 47 AM" src="https://github.com/user-attachments/assets/e918a83c-d0c0-4963-b0a6-a36ffc3fe508">
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.
