### PR TITLE
Go 1.23.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use the official Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23 AS builder
+FROM golang:1.23.4 AS builder
 
 # Set the current working directory inside the container.
 WORKDIR /go/src/github.com/score-spec/score-compose

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/score-spec/score-compose
 
-go 1.23
-
-toolchain go1.23.0
+go 1.23.4
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION
- In `Dockerfile`: `1.23` --> `1.23.4`
- In `go.mod`: `1.23` --> `1.23.4`

For reproducible build/release based on a specific Go version.

Note: we could have the digest for the base image in the `Dockerfile`, but not going that path for now.