### PR TITLE
feat(default-provisioner): add mssql default provisioner support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 | mongodb       | default | (none)                 | `host`, `port`, `username`, `password`, `connection`                                                                                                            |
 | kafka-topic   | default | (none)                 | `host`, `port`, `name`, `num_partitions`                                                                                                                        |
 | elasticsearch | default | (none)                 | `host`, `port`, `username`, `password`                                                                                                                          |
-| mssql         | default | (none)                 | `host`, `port`, `connection`, `database`, `username`, `password`                                                                                              |
+| mssql         | default | (none)                 | `host`, `port`, `connection`, `database`, `username`, `password`, `pid`                                                                                         |
 
 These can be found in the default provisioners file. You are encouraged to write your own provisioners and add them to the `.score-compose` directory (with the `.provisioners.yaml` extension) or contribute them upstream to the [default.provisioners.yaml](internal/command/default.provisioners.yaml) file.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 | mongodb       | default | (none)                 | `host`, `port`, `username`, `password`, `connection`                                                                                                            |
 | kafka-topic   | default | (none)                 | `host`, `port`, `name`, `num_partitions`                                                                                                                        |
 | elasticsearch | default | (none)                 | `host`, `port`, `username`, `password`                                                                                                                          |
-| mssql         | default | (none)                 | `host`, `port`, `connection`, `database`, `username`, `password`, `pid`                                                                                         |
+| mssql         | default | (none)                 | `server`, `port`, `connection`, `database`, `username`, `password`                                                                                              |
 
 These can be found in the default provisioners file. You are encouraged to write your own provisioners and add them to the `.score-compose` directory (with the `.provisioners.yaml` extension) or contribute them upstream to the [default.provisioners.yaml](internal/command/default.provisioners.yaml) file.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 | mongodb       | default | (none)                 | `host`, `port`, `username`, `password`, `connection`                                                                                                            |
 | kafka-topic   | default | (none)                 | `host`, `port`, `name`, `num_partitions`                                                                                                                        |
 | elasticsearch | default | (none)                 | `host`, `port`, `username`, `password`                                                                                                                          |
+| mssql         | default | (none)                 | `host`, `port`, `connection`, `database`, `username`, `password`                                                                                              |
 
 These can be found in the default provisioners file. You are encouraged to write your own provisioners and add them to the `.score-compose` directory (with the `.provisioners.yaml` extension) or contribute them upstream to the [default.provisioners.yaml](internal/command/default.provisioners.yaml) file.
 
@@ -68,6 +69,7 @@ See the [examples](./examples) for more examples of using Score and provisioning
 - [12-mysql-database](examples/12-mysql-database) - an example of the default `mysql` resource provisioner
 - [13-kafka-topic](examples/13-kafka-topic) - an example of the default `kafka-topic` resource provisioner
 - [14-elasticsearch](examples/14-elasticsearch) - an example of the default `elasticsearch` resource provisioner
+- [15-mssql-database](examples/15-mssql-database) - an example of the default `mssql` resource provisioner
 
 If you're getting started, you can use `score-compose init` to create a basic `score.yaml` file in the current directory along with a `.score-compose/` working directory.
 

--- a/examples/15-mssql-database/README.md
+++ b/examples/15-mssql-database/README.md
@@ -12,9 +12,8 @@ resources:
     # metadata:
       # annotations:
         # "compose.score.dev/publish-port": "1434"
-        # "compose.score.dev/mssql-pid": "Developer" refer to https://mcr.microsoft.com/artifact/mar/mssql/server/about
 ```
 
-The provided outputs are `host`, `port`, `connection`, `database`, `username`, `password`, `pid`.
+The provided outputs are `server`, `port`, `connection`, `database`, `username`, `password`.
 The latter is equal to a mssql
-connection string like `Server=${resources.db.host}; Database=${resources.db.database}; User=${resources.db.username}; Password=${resources.db.password};`.
+connection string like `Server=${resources.db.server}; Database=${resources.db.database}; User=${resources.db.username}; Password=${resources.db.password};`.

--- a/examples/15-mssql-database/README.md
+++ b/examples/15-mssql-database/README.md
@@ -17,4 +17,4 @@ resources:
 
 The provided outputs are `host`, `port`, `connection`, `database`, `username`, `password`, `pid`.
 The latter is equal to a mssql
-connection string like `Server=${resources.db.host}; Database=${resources.db.name}; User=${resources.db.username}; Password=${resources.db.password};`.
+connection string like `Server=${resources.db.host}; Database=${resources.db.database}; User=${resources.db.username}; Password=${resources.db.password};`.

--- a/examples/15-mssql-database/README.md
+++ b/examples/15-mssql-database/README.md
@@ -1,0 +1,20 @@
+# 12 - MSSQL Server database
+
+There is also a `mssql` resource provisioner as an example
+of a mssql database. This uses the official image from <https://hub.docker.com/r/microsoft/mssql-serverl>.
+
+```yaml
+resources:
+  db:
+    type: mssql
+    # Optionally, you can overwrite the port that will be published
+    # by commenting out the following lines
+    # metadata:
+      # annotations:
+        # "compose.score.dev/publish-port": "1434"
+        # "compose.score.dev/mssql-pid": "Developer" refer to https://mcr.microsoft.com/artifact/mar/mssql/server/about
+```
+
+The provided outputs are `host`, `port`, `connection`, `database`, `username`, `password`, `pid`.
+The latter is equal to a mssql
+connection string like `Server=${resources.db.host}; Database=${resources.db.name}; User=${resources.db.username}; Password=${resources.db.password};`.

--- a/examples/15-mssql-database/score.yaml
+++ b/examples/15-mssql-database/score.yaml
@@ -1,14 +1,14 @@
 apiVersion: score.dev/v1b1
 
 metadata:
-  name: hello-world
+  name: example
 
 containers:
   first:
     image: nginx
     variables:
-      CONNECTION_STRING: "mysql://${resources.db.username}:${resources.db.password}@${resources.db.host}:${resources.db.port}/${resources.db.name}"
+      CONNECTION_STRING: "Server=${resources.db.host}; Database=${resources.db.name}; User=${resources.db.username}; Password=${resources.db.password};"
 
 resources:
   db:
-    type: mysql
+    type: mssql

--- a/examples/15-mssql-database/score.yaml
+++ b/examples/15-mssql-database/score.yaml
@@ -1,0 +1,14 @@
+apiVersion: score.dev/v1b1
+
+metadata:
+  name: hello-world
+
+containers:
+  first:
+    image: nginx
+    variables:
+      CONNECTION_STRING: "mysql://${resources.db.username}:${resources.db.password}@${resources.db.host}:${resources.db.port}/${resources.db.name}"
+
+resources:
+  db:
+    type: mysql

--- a/examples/15-mssql-database/score.yaml
+++ b/examples/15-mssql-database/score.yaml
@@ -7,7 +7,7 @@ containers:
   first:
     image: nginx
     variables:
-      CONNECTION_STRING: "Server=${resources.db.host}; Database=${resources.db.name}; User=${resources.db.username}; Password=${resources.db.password};"
+      CONNECTION_STRING: "Server=${resources.db.host}; Database=${resources.db.database}; User=${resources.db.username}; Password=${resources.db.password};"
 
 resources:
   db:

--- a/examples/15-mssql-database/score.yaml
+++ b/examples/15-mssql-database/score.yaml
@@ -7,7 +7,7 @@ containers:
   first:
     image: nginx
     variables:
-      CONNECTION_STRING: "Server=${resources.db.host}; Database=${resources.db.database}; User=${resources.db.username}; Password=${resources.db.password};"
+      MSSQL_CONNECTION_STRING: "Server=${resources.db.server}; Database=${resources.db.database}; User=${resources.db.username}; Password=${resources.db.password};"
 
 resources:
   db:

--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -806,22 +806,19 @@
     randomPassword: {{ randAlphaNum 16 | quote }}
     sk: default-provisioners-mssql
     publishPort: {{ dig "annotations" "compose.score.dev/publish-port" "0" .Metadata | quote }}
-    pid: {{ dig "annotations" "compose.score.dev/mssql-pid" "Developer" .Metadata | quote }}
   state: |
     service: {{ .Init.sk }}
     database: master
     username: sa
     password: {{ dig "password" .Init.randomPassword .State | quote }}
     publishPort: {{ .Init.publishPort }}
-    pid: {{ .Init.pid }}
   outputs: |
-    host: {{ .State.service }}
+    server: {{ .State.service }}
     port: {{ .State.publishPort }}
     connection: "Server=tcp:{{ .State.service }},1433;Initial Catalog={{ .State.database }};User ID={{ .State.username }};Password={{ .State.password }};"
     database: {{ .State.database }}
     username: {{ .State.username }}
     password: {{ .State.password }}
-    pid: {{ .Init.pid }}
   volumes: |
     {{ .Init.sk }}-data:
       driver: local
@@ -834,7 +831,6 @@
         ACCEPT_EULA: "Y"
         MSSQL_ENABLE_HADR: "1"
         MSSQL_AGENT_ENABLED: "1"
-        MSSQL_PID: {{ .State.pid }}
         MSSQL_SA_PASSWORD: {{ .State.password }}
       {{ if ne .Init.publishPort "0" }}
       ports:
@@ -846,7 +842,7 @@
         source: {{ .Init.sk }}-data
         target: /var/opt/mssql
   info_logs: |
-    - "{{.Uid}}: To connect to mssql, enter password {{ .State.password | squote }} at: \"docker run -it --network {{ .ComposeProjectName }}_default --rm mcr.microsoft.com/mssql/server:latest mysql /opt/mssql-tools/bin/sqlcmd -S localhost -U {{ .State.username }} -p\""
+    - "{{.Uid}}: To connect to mssql: \"docker run -it --network {{ .ComposeProjectName }}_default --rm mcr.microsoft.com/mssql/server:latest mysql /opt/mssql-tools/bin/sqlcmd -S localhost -U {{ .State.username }} -p {{ .State.password | squote }}\""
     {{ if ne .Init.publishPort "0" }}
     - "{{.Uid}}: Or connect your mssql client to \"
     Server=tcp:{{ .State.service }},1433;Initial Catalog={{ .State.database }};User ID={{ .State.username }};Password={{ .State.password }};\""

--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -799,3 +799,55 @@
         \tdocker cp [CONTAINER-NAME]:/usr/share/elasticsearch/config/certs/ca/ca.crt /tmp/ \n
         and than check connection per culr like: \n
         \tcurl --cacert /tmp/ca.crt -u {{ .State.username }}:{{ .State.password }} https://localhost:{{ .Init.publishPort }}"
+
+- uri: template://default-provisioners/mssql
+  type: mssql
+  init: |
+    randomPassword: {{ randAlphaNum 16 | quote }}
+    sk: default-provisioners-mssql
+    publishPort: {{ dig "annotations" "compose.score.dev/publish-port" "0" .Metadata | quote }}
+    pid: {{ dig "annotations" "compose.score.dev/mssql-pid" "Developer" .Metadata | quote }}
+  state: |
+    service: mssql-{{ .SourceWorkload }}-{{ substr 0 8 .Guid | lower }}
+    database: master
+    username: sa
+    password: {{ dig "password" .Init.randomPassword .State | quote }}
+    publishPort: {{ .Init.publishPort }}
+    pid: {{ .Init.pid }}
+  outputs: |
+    host: {{ .State.service }}
+    port: {{ .State.publishPort }}
+    connection: "Server=tcp:{{ .State.service }},1433;Initial Catalog={{ .State.database }};User ID={{ .State.username }};Password={{ .State.passowrd }};"
+    database: {{ .State.database }}
+    username: {{ .State.username }}
+    password: {{ .State.passowrd }}
+    pid: {{ .Init.pid }}
+  volumes: |
+    {{ .Init.sk }}-data:
+      driver: local
+  # Create an services with the database itself
+  services: |
+    {{ .Init.sk }}:
+      image: mcr.microsoft.com/mssql/server:latest
+      restart: always
+      environment:
+        ACCEPT_EULA: "Y"
+        MSSQL_ENABLE_HADR: "1"
+        MSSQL_AGENT_ENABLED: "1"
+        MSSQL_PID: {{ .State.pid }}
+        MSSQL_SA_PASSWORD: {{ .State.passowrd }}
+      {{ if ne .Init.publishPort "0" }}
+      ports:
+      - target: 1433
+        published: {{ .Init.publishPort }}
+      {{ end }}
+      volumes:
+      - type: volume
+        source: {{{ .Init.sk }}-data
+        target: /var/opt/mssql
+  info_logs: |
+    - "{{.Uid}}: To connect to mssql, enter password {{ .State.password | squote }} at: \"docker run -it --network {{ .ComposeProjectName }}_default --rm mcr.microsoft.com/mssql/server:latest mysql /opt/mssql-tools/bin/sqlcmd -S localhost -U {{ dig .Init.username }} -p\""
+    {{ if ne .Init.publishPort "0" }}
+    - "{{.Uid}}: Or connect your mssql client to \"
+    Server=tcp:{{ .State.service }},1433;Initial Catalog={{ .State.database }};User ID={{ .State.username }};Password={{ .State.passowrd }};\""
+    {{ end }}

--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -817,10 +817,10 @@
   outputs: |
     host: {{ .State.service }}
     port: {{ .State.publishPort }}
-    connection: "Server=tcp:{{ .State.service }},1433;Initial Catalog={{ .State.database }};User ID={{ .State.username }};Password={{ .State.passowrd }};"
+    connection: "Server=tcp:{{ .State.service }},1433;Initial Catalog={{ .State.database }};User ID={{ .State.username }};Password={{ .State.password }};"
     database: {{ .State.database }}
     username: {{ .State.username }}
-    password: {{ .State.passowrd }}
+    password: {{ .State.password }}
     pid: {{ .Init.pid }}
   volumes: |
     {{ .Init.sk }}-data:
@@ -835,7 +835,7 @@
         MSSQL_ENABLE_HADR: "1"
         MSSQL_AGENT_ENABLED: "1"
         MSSQL_PID: {{ .State.pid }}
-        MSSQL_SA_PASSWORD: {{ .State.passowrd }}
+        MSSQL_SA_PASSWORD: {{ .State.password }}
       {{ if ne .Init.publishPort "0" }}
       ports:
       - target: 1433
@@ -849,5 +849,5 @@
     - "{{.Uid}}: To connect to mssql, enter password {{ .State.password | squote }} at: \"docker run -it --network {{ .ComposeProjectName }}_default --rm mcr.microsoft.com/mssql/server:latest mysql /opt/mssql-tools/bin/sqlcmd -S localhost -U {{ dig .Init.username }} -p\""
     {{ if ne .Init.publishPort "0" }}
     - "{{.Uid}}: Or connect your mssql client to \"
-    Server=tcp:{{ .State.service }},1433;Initial Catalog={{ .State.database }};User ID={{ .State.username }};Password={{ .State.passowrd }};\""
+    Server=tcp:{{ .State.service }},1433;Initial Catalog={{ .State.database }};User ID={{ .State.username }};Password={{ .State.password }};\""
     {{ end }}

--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -808,7 +808,7 @@
     publishPort: {{ dig "annotations" "compose.score.dev/publish-port" "0" .Metadata | quote }}
     pid: {{ dig "annotations" "compose.score.dev/mssql-pid" "Developer" .Metadata | quote }}
   state: |
-    service: mssql-{{ .SourceWorkload }}-{{ substr 0 8 .Guid | lower }}
+    service: {{ .Init.sk }}
     database: master
     username: sa
     password: {{ dig "password" .Init.randomPassword .State | quote }}
@@ -843,10 +843,10 @@
       {{ end }}
       volumes:
       - type: volume
-        source: {{{ .Init.sk }}-data
+        source: {{ .Init.sk }}-data
         target: /var/opt/mssql
   info_logs: |
-    - "{{.Uid}}: To connect to mssql, enter password {{ .State.password | squote }} at: \"docker run -it --network {{ .ComposeProjectName }}_default --rm mcr.microsoft.com/mssql/server:latest mysql /opt/mssql-tools/bin/sqlcmd -S localhost -U {{ dig .Init.username }} -p\""
+    - "{{.Uid}}: To connect to mssql, enter password {{ .State.password | squote }} at: \"docker run -it --network {{ .ComposeProjectName }}_default --rm mcr.microsoft.com/mssql/server:latest mysql /opt/mssql-tools/bin/sqlcmd -S localhost -U {{ .State.username }} -p\""
     {{ if ne .Init.publishPort "0" }}
     - "{{.Uid}}: Or connect your mssql client to \"
     Server=tcp:{{ .State.service }},1433;Initial Catalog={{ .State.database }};User ID={{ .State.username }};Password={{ .State.password }};\""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Add a defalult MSSQL provisioner

#### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #195 


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.

#### Local tests

```bash
# Init
~$ go run ../../cmd/score-compose/main.go init -f ./score.yaml 
INFO: Writing new state directory '.score-compose'
INFO: Writing new state directory '.score-compose' with project name '15-mssql-database'
INFO: Writing default provisioners yaml file 'zz-default.provisioners.yaml'
INFO: Found existing Score file './score.yaml'

# Generate
$ go run ../../cmd/score-compose/main.go generate score.yaml 
INFO: Loaded state directory with docker compose project '15-mssql-database'
INFO: Validated workload 'example'
INFO: Successfully loaded 13 resource provisioners
INFO: mssql.default#example.db: mssql.default#example.db: To connect to mssql: "docker run -it --network 15-mssql-database_default --rm mcr.microsoft.com/mssql/server:latest mysql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -p '*******'"
INFO: Provisioned 1 resources
INFO: Converting workload 'example' to Docker compose

```
