### PR TITLE
fix: don't unescape dollars in environment variable placeholders

### DIFF
--- a/examples/02-environment/README.md
+++ b/examples/02-environment/README.md
@@ -21,6 +21,7 @@ containers:
       GREETING: Hello
       NAME: ${resources.env.NAME}
       WORKLOAD_NAME: ${metadata.name}
+      ESCAPED: $$_$${fizzbuzz}
 
 resources:
   env:
@@ -48,6 +49,7 @@ services:
         entrypoint:
             - /bin/sh
         environment:
+            ESCAPED: $$_$${fizzbuzz}
             GREETING: Hello
             NAME: ${NAME}
             WORKLOAD_NAME: hello-world

--- a/examples/02-environment/score.yaml
+++ b/examples/02-environment/score.yaml
@@ -12,6 +12,7 @@ containers:
       GREETING: Hello
       NAME: ${resources.env.NAME}
       WORKLOAD_NAME: ${metadata.name}
+      ESCAPED: $$_$${fizzbuzz}
 
 resources:
   env:

--- a/internal/command/generate_examples_test.go
+++ b/internal/command/generate_examples_test.go
@@ -68,6 +68,7 @@ services:
         entrypoint:
             - /bin/sh
         environment:
+            ESCAPED: $$_$${fizzbuzz}
             GREETING: Hello
             NAME: ${NAME}
             WORKLOAD_NAME: hello-world

--- a/internal/compose/convert.go
+++ b/internal/compose/convert.go
@@ -68,13 +68,20 @@ func ConvertSpec(state *project.State, spec *score.Workload) (*compose.Project, 
 	}
 	sort.Strings(containerNames)
 
+	variablesSubstitutor := framework.Substituter{
+		Replacer: deferredSubstitutionFunction,
+		UnEscaper: func(s string) (string, error) {
+			return s, nil
+		},
+	}
+
 	var firstService string
 	for _, containerName := range containerNames {
 		cSpec := spec.Containers[containerName]
 
 		var env = make(compose.MappingWithEquals, len(cSpec.Variables))
 		for key, val := range cSpec.Variables {
-			resolved, err := framework.SubstituteString(val, deferredSubstitutionFunction)
+			resolved, err := variablesSubstitutor.SubstituteString(val)
 			if err != nil {
 				return nil, fmt.Errorf("containers.%s.variables.%s: %w", containerName, key, err)
 			}

--- a/internal/compose/convert_test.go
+++ b/internal/compose/convert_test.go
@@ -156,7 +156,7 @@ func TestScoreConvert(t *testing.T) {
 						Image:    "busybox",
 						Environment: compose.MappingWithEquals{
 							"DEBUG":             stringPtr("${DEBUG}"),
-							"LOGS_LEVEL":        stringPtr("${LOGS_LEVEL}"),
+							"LOGS_LEVEL":        stringPtr("$${LOGS_LEVEL}"),
 							"DOMAIN_NAME":       stringPtr("${SOME_DNS_DOMAIN_NAME?required}"),
 							"CONNECTION_STRING": stringPtr("postgresql://${APP_DB_HOST?required}:${APP_DB_PORT?required}/${APP_DB_NAME?required}"),
 						},
@@ -229,7 +229,7 @@ func TestScoreConvert(t *testing.T) {
 						Image:    "busybox",
 						Environment: compose.MappingWithEquals{
 							"DEBUG":             stringPtr("${DEBUG}"),
-							"LOGS_LEVEL":        stringPtr("${LOGS_LEVEL}"),
+							"LOGS_LEVEL":        stringPtr("$${LOGS_LEVEL}"),
 							"DOMAIN_NAME":       stringPtr("${SOME_DNS_DOMAIN_NAME?required}"),
 							"CONNECTION_STRING": stringPtr("mysql://${APP_DB_HOST?required}:${APP_DB_PORT?required}/${APP_DB_NAME?required}"),
 						},


### PR DESCRIPTION
This finishes off the last bit of work and fixes #148.

We need to use the custom unescaper to not escape the variables here. This allows it to match the expected runtime behavior.
