### PR TITLE
fix: remove mergo replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/score-spec/score-compose
 go 1.23.4
 
 require (
+	dario.cat/mergo v1.0.1
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/compose-spec/compose-go/v2 v2.4.7
-	github.com/imdario/mergo v1.0.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/score-spec/score-go v1.9.0
 	github.com/spf13/cobra v1.8.1
@@ -16,7 +16,6 @@ require (
 )
 
 require (
-	dario.cat/mergo v1.0.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -50,5 +49,3 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	oras.land/oras-go/v2 v2.5.0 // indirect
 )
-
-replace github.com/imdario/mergo => dario.cat/mergo v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
-dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
@@ -55,8 +53,6 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
-github.com/score-spec/score-go v1.8.5 h1:ssCvGojcM+cs+GK7/GuE2oA5iDoCqcAofL/Usce4UFI=
-github.com/score-spec/score-go v1.8.5/go.mod h1:rW7jKWPPqubDzHmIlE/r/x5z64Q4eMdjKCxZ8XB+/LM=
 github.com/score-spec/score-go v1.9.0 h1:PLuRZHduzL4jIPIbHjLFYZN6HlHwlbl217hL9tIURaY=
 github.com/score-spec/score-go v1.9.0/go.mod h1:rW7jKWPPqubDzHmIlE/r/x5z64Q4eMdjKCxZ8XB+/LM=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/command/generate.go
+++ b/internal/command/generate.go
@@ -23,9 +23,9 @@ import (
 	"strconv"
 	"strings"
 
+	"dario.cat/mergo"
 	composeloader "github.com/compose-spec/compose-go/v2/loader"
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/imdario/mergo"
 	"github.com/score-spec/score-go/framework"
 	"github.com/score-spec/score-go/loader"
 	"github.com/score-spec/score-go/schema"

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -24,8 +24,8 @@ import (
 	"sort"
 	"strings"
 
+	"dario.cat/mergo"
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/imdario/mergo"
 	"github.com/score-spec/score-go/framework"
 	"github.com/spf13/cobra"
 	"github.com/tidwall/sjson"
@@ -74,11 +74,11 @@ func init() {
 }
 
 var runCmd = &cobra.Command{
-	Use:   "run [--file=score.yaml] [--output=compose.yaml]",
-	Args:  cobra.NoArgs,
-	Short: "(Deprecated) Translate the SCORE file to docker-compose configuration",
+	Use:    "run [--file=score.yaml] [--output=compose.yaml]",
+	Args:   cobra.NoArgs,
+	Short:  "(Deprecated) Translate the SCORE file to docker-compose configuration",
 	Hidden: true,
-	RunE:  run,
+	RunE:   run,
 	// don't print the errors - we print these ourselves in main()
 	SilenceErrors: true,
 }


### PR DESCRIPTION
The mergo replace directive that used be necessary was still hanging around and preventing the user of `go run github.com/score-spec/score-compose/cmd/score-compose@0.24.0` when run inside a go module.

This PR fixes it now that `dario.cat/mergo` has the correct redirects in place.