### PR TITLE
chore: update go to 1.23.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/score-spec/score-compose
 
-go 1.23.4
+go 1.23.5
 
 require (
 	dario.cat/mergo v1.0.1


### PR DESCRIPTION
As it says on the tin, update the binary go version. For some reason missed by dependabot.