### PR TITLE
Fix `--version`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,8 @@ jobs:
           push: false
           load: true
           tags: score-compose:test
+          build-args: |
+            "VERSION=test"
       - name: Test docker image
         run: |
           docker run --rm score-compose:test --version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,8 @@ jobs:
           tags: |
             ghcr.io/score-spec/score-compose:${{ github.ref_name }}
             ghcr.io/score-spec/score-compose:latest
+          build-args: |
+            "VERSION=${{ github.ref_name }}"
       - name: Sign container image
         run: |
           cosign sign --yes ghcr.io/score-spec/score-compose@${{ steps.build-push-container.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-# Use the official Golang image to create a build artifact.
-# This is based on Debian and sets the GOPATH to /go.
-# https://hub.docker.com/_/golang
-FROM golang:1.24.0@sha256:3f7444391c51a11a039bf0359ee81cc64e663c17d787ad0e637a4de1a3f62a71 AS builder
+FROM golang:1.24.0-alpine@sha256:2d40d4fc278dad38be0777d5e2a88a2c6dee51b0b29c97a764fc6c6a11ca893c AS builder
+
+ARG VERSION=0.0.0
 
 # Set the current working directory inside the container.
 WORKDIR /go/src/github.com/score-spec/score-compose
@@ -12,7 +11,7 @@ RUN go mod download
 
 # Copy the entire project and build it.
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o /usr/local/bin/score-compose ./cmd/score-compose
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-X github.com/score-spec/score-compose/internal/version.Version=${VERSION}" -o /usr/local/bin/score-compose ./cmd/score-compose
 
 # We can use gcr.io/distroless/static since we don't rely on any linux libs or state, but we need ca-certificates to connect to https/oci with the init command.
 FROM gcr.io/distroless/static:530158861eebdbbf149f7e7e67bfe45eb433a35c@sha256:5c7e2b465ac6a2a4e5f4f7f722ce43b147dabe87cb21ac6c4007ae5178a1fa58

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -25,9 +25,6 @@ var (
 func BuildVersionString() string {
 	versionNumber, buildTime, gitSha, isDirtySuffix := Version, "local", "unknown", ""
 	if info, ok := debug.ReadBuildInfo(); ok {
-		if info.Main.Version != "" && info.Main.Version != "(devel)" {
-			versionNumber = info.Main.Version
-		}
 		for _, setting := range info.Settings {
 			switch setting.Key {
 			case "vcs.time":


### PR DESCRIPTION
Fixing https://github.com/score-spec/score-compose/issues/268.

Not related to the regression between `0.24.2` and `0.25.0`, also fixing an issue that has been there for a long time with the container image with the `--version`:
```bash
score-compose 0.0.0 (build: 2025-01-21T17:02:05Z, sha: 974fdcebfa674487e9626a1a83951c07476b3273-dirty)
```

Knowing that the `goreleaser` config was already using this: https://github.com/score-spec/score-compose/blob/main/.goreleaser.yaml#L11.

_Note: Not related to this PR, but the container base image to build the final image (`distroless`) is now based on `alpine` in order to speed up the container build process._