### PR TITLE
Postgres-instance provisioner added

### DIFF
--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -217,11 +217,10 @@
     - password
 
 
-- uri: template://default-provisioners/postgres
-  # By default, match all redis types regardless of class and id. If you want to override this, create another
-  # provisioner definition with a higher priority.
+- uri: template://default-provisioners/postgres-instance
+ 
   type: postgres-instance
-  description: Provisions a dedicated database on a shared postgres instance
+  description: Provisions a dedicated Postgres instance
   # Init template has the random service name and password if needed later
   init: |
     randomServiceName: pg-{{ randAlphaNum 6 }}
@@ -232,23 +231,15 @@
     publishPort: {{ dig "annotations" "compose.score.dev/publish-port" "0" .Metadata | quote }}
   # The state for each database resource is a unique db name and credentials
   state: |
-    database: {{ dig "database" .Init.randomDatabase .State | quote }}
-    username: {{ dig "username" .Init.randomUsername .State | quote }}
+    database: "postgres"
+    username: "postgres"
     password: {{ dig "password" .Init.randomPassword .State | quote }}
   # The outputs are the core database outputs. We output both name and database for broader compatibility.
   outputs: |
     host: {{ dig .Init.sk "instanceServiceName" "" .Shared }}
     port: 5432
-    username: {{ .State.username }}
-    password: {{ .State.password }}
-  # Write out an idempotent create script per database
-  files: |
-    {{ dig .Init.sk "instanceServiceName" "" .Shared }}-db-scripts/{{ .State.database }}.sql: |
-      SELECT 'CREATE DATABASE "{{ .State.database }}"' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '{{ .State.database }}')\gexec
-      SELECT $$CREATE USER "{{ .State.username }}" WITH PASSWORD '{{ .State.password }}'$$ WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '{{ .State.username }}')\gexec
-      GRANT ALL PRIVILEGES ON DATABASE "{{ .State.database }}" TO "{{ .State.username }}";
-      \connect "{{ .State.database }}";
-      GRANT ALL ON SCHEMA public TO "{{ .State.username }}";
+    username: postgres
+    password: {{ dig .Init.sk "instancePassword" "" .Shared }}
   # Ensure the data volume exists
   volumes: |
     {{ dig .Init.sk "instanceServiceName" "" .Shared }}-data:
@@ -272,29 +263,7 @@
         target: /var/lib/postgresql/data
       healthcheck:
         test: ["CMD", "pg_isready", "-U", "postgres"]
-        interval: 2s
-        timeout: 2s
-        retries: 15
-    {{ dig .Init.sk "instanceServiceName" "" .Shared }}-init:
-      image: mirror.gcr.io/postgres:17-alpine
-      entrypoint: ["/bin/sh"]
-      environment:
-        POSTGRES_PASSWORD: {{ dig .Init.sk "instancePassword" "" .Shared | quote }}
-      command:
-      - "-c"
-      - |
-        cd /db-scripts
-        ls db-*.sql | xargs cat | psql "postgresql://postgres:$${POSTGRES_PASSWORD}@{{ dig .Init.sk "instanceServiceName" "" .Shared }}:5432/postgres"
-      labels:
-        dev.score.compose.labels.is-init-container: "true"
-      depends_on:
-        {{ dig .Init.sk "instanceServiceName" "" .Shared }}:
-          condition: service_healthy
-          restart: true
-      volumes:
-      - type: bind
-        source: {{ .MountsDirectory }}/{{ dig .Init.sk "instanceServiceName" "" .Shared }}-db-scripts
-        target: /db-scripts
+      
   info_logs: |
     - "{{.Uid}}: To connect to postgres, enter password {{ .State.password | squote }} at: \"docker run -it --network {{ .ComposeProjectName }}_default --rm postgres:17-alpine psql -h {{ dig .Init.sk "instanceServiceName" "" .Shared }} -U {{ .State.username }} --dbname {{ .State.database }}\""
     {{ if ne .Init.publishPort "0" }}

--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -231,27 +231,28 @@
     publishPort: {{ dig "annotations" "compose.score.dev/publish-port" "0" .Metadata | quote }}
   # The state for each database resource is a unique db name and credentials
   state: |
+    serviceName: {{ .Init.randomServiceName }}
     database: "postgres"
     username: "postgres"
     password: {{ dig "password" .Init.randomPassword .State | quote }}
   # The outputs are the core database outputs. We output both name and database for broader compatibility.
   outputs: |
-    host: {{ dig .Init.sk "instanceServiceName" "" .Shared }}
+    host: {{ .State.serviceName }}
     port: 5432
     username: postgres
-    password: {{ dig .Init.sk "instancePassword" "" .Shared }}
+    password: {{ .State.password }}
   # Ensure the data volume exists
   volumes: |
-    {{ dig .Init.sk "instanceServiceName" "" .Shared }}-data:
+    {{ .State.serviceName }}-data:
       driver: local
   # Create 2 services, the first is the database itself, the second is the init container which runs the scripts
   services: |
-    {{ dig .Init.sk "instanceServiceName" "" .Shared }}:
+    {{ .State.serviceName }}:
       image: mirror.gcr.io/postgres:17-alpine
       restart: always
       environment:
         POSTGRES_USER: postgres
-        POSTGRES_PASSWORD: {{ dig .Init.sk "instancePassword" "" .Shared | quote }}
+        POSTGRES_PASSWORD: {{ .State.password | quote }}
       {{ if ne .Init.publishPort "0" }}
       ports:
       - target: 5432
@@ -259,13 +260,13 @@
       {{ end }}
       volumes:
       - type: volume
-        source: {{ dig .Init.sk "instanceServiceName" "" .Shared }}-data
+        source: {{ .State.serviceName }}-data
         target: /var/lib/postgresql/data
       healthcheck:
         test: ["CMD", "pg_isready", "-U", "postgres"]
       
   info_logs: |
-    - "{{.Uid}}: To connect to postgres, enter password {{ .State.password | squote }} at: \"docker run -it --network {{ .ComposeProjectName }}_default --rm postgres:17-alpine psql -h {{ dig .Init.sk "instanceServiceName" "" .Shared }} -U {{ .State.username }} --dbname {{ .State.database }}\""
+    - "{{.Uid}}: To connect to postgres, enter password {{ .State.password | squote }} at: \"docker run -it --network {{ .ComposeProjectName }}_default --rm postgres:17-alpine psql -h {{ .State.serviceName }} -U {{ .State.username }} --dbname {{ .State.database }}\""
     {{ if ne .Init.publishPort "0" }}
     - "{{.Uid}}: Or connect your postgres client to \"postgres://{{ .State.username }}:{{ .State.password }}@localhost:{{ .Init.publishPort }}/{{ .State.database }}\""
     {{ end }}

--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -231,7 +231,7 @@
     publishPort: {{ dig "annotations" "compose.score.dev/publish-port" "0" .Metadata | quote }}
   # The state for each database resource is a unique db name and credentials
   state: |
-    serviceName: {{ .Init.randomServiceName }}
+    serviceName: {{ dig "serviceName" .Init.randomServiceName .State | quote }}
     database: "postgres"
     username: "postgres"
     password: {{ dig "password" .Init.randomPassword .State | quote }}

--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -235,11 +235,6 @@
     database: {{ dig "database" .Init.randomDatabase .State | quote }}
     username: {{ dig "username" .Init.randomUsername .State | quote }}
     password: {{ dig "password" .Init.randomPassword .State | quote }}
-  # All instances agree on the shared state since there is no concurrency here
-  shared: |
-    {{ .Init.sk }}:
-      instanceServiceName: {{ dig .Init.sk "instanceServiceName" .Init.randomServiceName .Shared | quote }}
-      instancePassword: {{ dig .Init.sk "instancePassword" .Init.randomPassword .Shared | quote }}
   # The outputs are the core database outputs. We output both name and database for broader compatibility.
   outputs: |
     host: {{ dig .Init.sk "instanceServiceName" "" .Shared }}

--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -216,6 +216,101 @@
     - username
     - password
 
+
+- uri: template://default-provisioners/postgres
+  # By default, match all redis types regardless of class and id. If you want to override this, create another
+  # provisioner definition with a higher priority.
+  type: postgres-instance
+  description: Provisions a dedicated database on a shared postgres instance
+  # Init template has the random service name and password if needed later
+  init: |
+    randomServiceName: pg-{{ randAlphaNum 6 }}
+    randomDatabase: db-{{ randAlpha 8 }}
+    randomUsername: user-{{ randAlpha 8 }}
+    randomPassword: {{ randAlphaNum 16 | quote }}
+    sk: default-provisioners-postgres-instance
+    publishPort: {{ dig "annotations" "compose.score.dev/publish-port" "0" .Metadata | quote }}
+  # The state for each database resource is a unique db name and credentials
+  state: |
+    database: {{ dig "database" .Init.randomDatabase .State | quote }}
+    username: {{ dig "username" .Init.randomUsername .State | quote }}
+    password: {{ dig "password" .Init.randomPassword .State | quote }}
+  # All instances agree on the shared state since there is no concurrency here
+  shared: |
+    {{ .Init.sk }}:
+      instanceServiceName: {{ dig .Init.sk "instanceServiceName" .Init.randomServiceName .Shared | quote }}
+      instancePassword: {{ dig .Init.sk "instancePassword" .Init.randomPassword .Shared | quote }}
+  # The outputs are the core database outputs. We output both name and database for broader compatibility.
+  outputs: |
+    host: {{ dig .Init.sk "instanceServiceName" "" .Shared }}
+    port: 5432
+    username: {{ .State.username }}
+    password: {{ .State.password }}
+  # Write out an idempotent create script per database
+  files: |
+    {{ dig .Init.sk "instanceServiceName" "" .Shared }}-db-scripts/{{ .State.database }}.sql: |
+      SELECT 'CREATE DATABASE "{{ .State.database }}"' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '{{ .State.database }}')\gexec
+      SELECT $$CREATE USER "{{ .State.username }}" WITH PASSWORD '{{ .State.password }}'$$ WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '{{ .State.username }}')\gexec
+      GRANT ALL PRIVILEGES ON DATABASE "{{ .State.database }}" TO "{{ .State.username }}";
+      \connect "{{ .State.database }}";
+      GRANT ALL ON SCHEMA public TO "{{ .State.username }}";
+  # Ensure the data volume exists
+  volumes: |
+    {{ dig .Init.sk "instanceServiceName" "" .Shared }}-data:
+      driver: local
+  # Create 2 services, the first is the database itself, the second is the init container which runs the scripts
+  services: |
+    {{ dig .Init.sk "instanceServiceName" "" .Shared }}:
+      image: mirror.gcr.io/postgres:17-alpine
+      restart: always
+      environment:
+        POSTGRES_USER: postgres
+        POSTGRES_PASSWORD: {{ dig .Init.sk "instancePassword" "" .Shared | quote }}
+      {{ if ne .Init.publishPort "0" }}
+      ports:
+      - target: 5432
+        published: {{ .Init.publishPort }}
+      {{ end }}
+      volumes:
+      - type: volume
+        source: {{ dig .Init.sk "instanceServiceName" "" .Shared }}-data
+        target: /var/lib/postgresql/data
+      healthcheck:
+        test: ["CMD", "pg_isready", "-U", "postgres"]
+        interval: 2s
+        timeout: 2s
+        retries: 15
+    {{ dig .Init.sk "instanceServiceName" "" .Shared }}-init:
+      image: mirror.gcr.io/postgres:17-alpine
+      entrypoint: ["/bin/sh"]
+      environment:
+        POSTGRES_PASSWORD: {{ dig .Init.sk "instancePassword" "" .Shared | quote }}
+      command:
+      - "-c"
+      - |
+        cd /db-scripts
+        ls db-*.sql | xargs cat | psql "postgresql://postgres:$${POSTGRES_PASSWORD}@{{ dig .Init.sk "instanceServiceName" "" .Shared }}:5432/postgres"
+      labels:
+        dev.score.compose.labels.is-init-container: "true"
+      depends_on:
+        {{ dig .Init.sk "instanceServiceName" "" .Shared }}:
+          condition: service_healthy
+          restart: true
+      volumes:
+      - type: bind
+        source: {{ .MountsDirectory }}/{{ dig .Init.sk "instanceServiceName" "" .Shared }}-db-scripts
+        target: /db-scripts
+  info_logs: |
+    - "{{.Uid}}: To connect to postgres, enter password {{ .State.password | squote }} at: \"docker run -it --network {{ .ComposeProjectName }}_default --rm postgres:17-alpine psql -h {{ dig .Init.sk "instanceServiceName" "" .Shared }} -U {{ .State.username }} --dbname {{ .State.database }}\""
+    {{ if ne .Init.publishPort "0" }}
+    - "{{.Uid}}: Or connect your postgres client to \"postgres://{{ .State.username }}:{{ .State.password }}@localhost:{{ .Init.publishPort }}/{{ .State.database }}\""
+    {{ end }}
+  expected_outputs:
+    - host
+    - port
+    - username
+    - password   
+
 # This resource provides a minio based S3 bucket with AWS-style credentials.
 # This provides some common and well known outputs that can be used with any generic AWS s3 client.
 # If the provider has a publish port annotation, it can expose a management port on the local network for debugging and


### PR DESCRIPTION
## Description
A new provisioner, `postgres-instance`, has been added. It is similar to the `postgres` provisioner but differs in key aspects:

- Unlike the `postgres` provisioner, `postgres-instance` does not provide `database/name` as an output.

- It operates without shared resources (local )