### PR TITLE
feat: add no-default-provisioners flag

### DIFF
--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -88,6 +88,7 @@ URI Retrieval:
 Flags:
   -f, --file string                   The score file to initialize (default "./score.yaml")
   -h, --help                          help for init
+      --no-default-provisioners       Disable generation of the default provisioners file
       --no-sample                     Disable generation of the sample score file
       --patch-templates stringArray   Patching template files to include. May be specified multiple times. Supports URI retrieval.
   -p, --project string                Set the name of the docker compose project (defaults to the current directory name)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
**Add `--no-default-provisioner flag`**
#### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Adds the ability to disable automatic creation of the default provisioners file (zz-default.provisioners.yaml) during score-compose init
#286 
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.
