### PR TITLE
Support new `files|volumes` spec with `score-go` `v1.10.0`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+# Disable all the default make stuff
+MAKEFLAGS += --no-builtin-rules
+.SUFFIXES:
+
+## Display a list of the documented make targets
+.PHONY: help
+help:
+	@echo Documented Make targets:
+	@perl -e 'undef $$/; while (<>) { while ($$_ =~ /## (.*?)(?:\n# .*)*\n.PHONY:\s+(\S+).*/mg) { printf "\033[36m%-30s\033[0m %s\n", $$2, $$1 } }' $(MAKEFILE_LIST) | sort
+
+.PHONY: .FORCE
+.FORCE:
+
+build:
+	go build ./cmd/score-compose/
+
+test:
+	go vet ./...    
+	go test ./... -cover -race

--- a/examples/03-files/score.yaml
+++ b/examples/03-files/score.yaml
@@ -9,10 +9,10 @@ containers:
     command: ["/bin/sh"]
     args: ["-c", "while true; do cat /fileA.txt; cat /fileB.txt; cat /fileC.bin; sleep 5; done"]
     files:
-      - target: /fileA.txt
+      "/fileA.txt":
         source: fileA.txt
-      - target: /fileB.txt
+      "/fileB.txt":
         content: |
           I am ${metadata.name}
-      - target: /fileC.bin
+      "/fileC.bin":
         binaryContent: aGVsbG8gd29ybGQ=

--- a/examples/05-volume-mounts/score.yaml
+++ b/examples/05-volume-mounts/score.yaml
@@ -7,7 +7,7 @@ containers:
   first:
     image: "nginx:latest"
     volumes:
-      - target: /data
+      "/data":
         source: ${resources.data}
 
 resources:

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/compose-spec/compose-go/v2 v2.6.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/score-spec/score-go v1.9.7
+	github.com/score-spec/score-go v1.10.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,6 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
-github.com/score-spec/score-go v1.9.7 h1:2afe1vSHIWafRcEc3484U9nGWPo6Fmr0T97ypjvMSLs=
-github.com/score-spec/score-go v1.9.7/go.mod h1:uvlaGT8wvBujAqU0aU2Kx3gFrq8owBGjjeUjWNI7/zY=
 github.com/score-spec/score-go v1.10.0 h1:ukWV2Df41uAYvLbVdRS1njmbedMCtp80zd6Pio3Wy60=
 github.com/score-spec/score-go v1.10.0/go.mod h1:bEtNhlGekZaNuWI11n15V5ibcX+E0Inry+TC6NWTuFI=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6Ng
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/score-spec/score-go v1.9.7 h1:2afe1vSHIWafRcEc3484U9nGWPo6Fmr0T97ypjvMSLs=
 github.com/score-spec/score-go v1.9.7/go.mod h1:uvlaGT8wvBujAqU0aU2Kx3gFrq8owBGjjeUjWNI7/zY=
+github.com/score-spec/score-go v1.10.0 h1:ukWV2Df41uAYvLbVdRS1njmbedMCtp80zd6Pio3Wy60=
+github.com/score-spec/score-go v1.10.0/go.mod h1:bEtNhlGekZaNuWI11n15V5ibcX+E0Inry+TC6NWTuFI=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=

--- a/internal/command/generate_examples_test.go
+++ b/internal/command/generate_examples_test.go
@@ -94,13 +94,13 @@ services:
         image: busybox
         volumes:
             - type: bind
-              source: .score-compose/mounts/files/hello-world-files-0-fileA.txt
+              source: .score-compose/mounts/files/hello-world-files-fileA.txt
               target: /fileA.txt
             - type: bind
-              source: .score-compose/mounts/files/hello-world-files-1-fileB.txt
+              source: .score-compose/mounts/files/hello-world-files-fileB.txt
               target: /fileB.txt
             - type: bind
-              source: .score-compose/mounts/files/hello-world-files-2-fileC.bin
+              source: .score-compose/mounts/files/hello-world-files-fileC.bin
               target: /fileC.bin
 `,
 		},

--- a/internal/command/generate_test.go
+++ b/internal/command/generate_test.go
@@ -360,7 +360,7 @@ services:
         image: foo
         volumes:
             - type: bind
-              source: .score-compose/mounts/files/example-files-0-blah.txt
+              source: .score-compose/mounts/files/example-files-blah.txt
               target: /blah.txt
 `, string(raw))
 }
@@ -996,7 +996,7 @@ resources:
     type: environment
 `), 0644))
 	_, _, err = executeAndResetCommand(context.Background(), rootCmd, []string{"generate", "score.yaml"})
-	assert.EqualError(t, err, "failed to convert workload 'example' to Docker compose: containers.example.files[0]: "+
+	assert.EqualError(t, err, "failed to convert workload 'example' to Docker compose: containers.example.files[/some/file]: "+
 		"failed to substitute in content: invalid ref 'resources.env.UNKNOWN_SCORE_VARIABLE': "+
 		"environment variable 'UNKNOWN_SCORE_VARIABLE' must be resolved",
 	)

--- a/internal/compose/convert.go
+++ b/internal/compose/convert.go
@@ -106,7 +106,7 @@ func ConvertSpec(state *project.State, spec *score.Workload) (*compose.Project, 
 		var volumes []compose.ServiceVolumeConfig
 		if len(cSpec.Volumes) > 0 {
 			volumes = make([]compose.ServiceVolumeConfig, 0, len(cSpec.Volumes))
-			for target := range slices.Sorted(maps.Keys(cSpec.Volumes)) {
+			for _, target := range slices.Sorted(maps.Keys(cSpec.Volumes)) {
 			    vol := cSpec.Volumes[target]
 				cfg, err := convertVolumeSourceIntoVolume(state, deferredSubstitutionFunction, workloadName, target, vol)
 				if err != nil {
@@ -240,7 +240,7 @@ func convertFilesIntoVolumes(state *project.State, workloadName string, containe
 	if err = os.MkdirAll(filesDir, 0755); err != nil && !errors.Is(err, os.ErrExist) {
 		return nil, fmt.Errorf("failed to ensure the files directory exists")
 	}
-	for target := range slices.Sorted(maps.Keys(input)) {
+	for _, target := range slices.Sorted(maps.Keys(input)) {
 	    file := input[target]
 		var content []byte
 		if file.Content != nil {

--- a/internal/compose/convert.go
+++ b/internal/compose/convert.go
@@ -105,7 +105,8 @@ func ConvertSpec(state *project.State, spec *score.Workload) (*compose.Project, 
 		if len(cSpec.Volumes) > 0 {
 			volumes = make([]compose.ServiceVolumeConfig, 0, len(cSpec.Volumes))
 			idx := 0
-			for target, vol := range cSpec.Volumes {
+			for target := range slices.Sorted(maps.Keys(cSpec.Volumes)) {
+			 vol := cSpec.Volumes[target]
 				cfg, err := convertVolumeSourceIntoVolume(state, deferredSubstitutionFunction, workloadName, target, vol)
 				if err != nil {
 					return nil, fmt.Errorf("containers.%s.volumes[%s]: %w", containerName, target, err)

--- a/internal/compose/convert.go
+++ b/internal/compose/convert.go
@@ -111,7 +111,7 @@ func ConvertSpec(state *project.State, spec *score.Workload) (*compose.Project, 
 				if err != nil {
 					return nil, fmt.Errorf("containers.%s.volumes[%s]: %w", containerName, target, err)
 				}
-				volumes[idx] = *cfg
+				volumes = append(volumes, *cfg)
 				idx++
 			}
 		}

--- a/internal/compose/convert.go
+++ b/internal/compose/convert.go
@@ -103,7 +103,7 @@ func ConvertSpec(state *project.State, spec *score.Workload) (*compose.Project, 
 
 		var volumes []compose.ServiceVolumeConfig
 		if len(cSpec.Volumes) > 0 {
-			volumes = make([]compose.ServiceVolumeConfig, len(cSpec.Volumes))
+			volumes = make([]compose.ServiceVolumeConfig, 0, len(cSpec.Volumes))
 			idx := 0
 			for target, vol := range cSpec.Volumes {
 				cfg, err := convertVolumeSourceIntoVolume(state, deferredSubstitutionFunction, workloadName, target, vol)

--- a/internal/compose/convert.go
+++ b/internal/compose/convert.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
+	"maps"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -104,15 +106,13 @@ func ConvertSpec(state *project.State, spec *score.Workload) (*compose.Project, 
 		var volumes []compose.ServiceVolumeConfig
 		if len(cSpec.Volumes) > 0 {
 			volumes = make([]compose.ServiceVolumeConfig, 0, len(cSpec.Volumes))
-			idx := 0
 			for target := range slices.Sorted(maps.Keys(cSpec.Volumes)) {
-			 vol := cSpec.Volumes[target]
+			    vol := cSpec.Volumes[target]
 				cfg, err := convertVolumeSourceIntoVolume(state, deferredSubstitutionFunction, workloadName, target, vol)
 				if err != nil {
 					return nil, fmt.Errorf("containers.%s.volumes[%s]: %w", containerName, target, err)
 				}
 				volumes = append(volumes, *cfg)
-				idx++
 			}
 		}
 
@@ -241,7 +241,7 @@ func convertFilesIntoVolumes(state *project.State, workloadName string, containe
 		return nil, fmt.Errorf("failed to ensure the files directory exists")
 	}
 	for target := range slices.Sorted(maps.Keys(input)) {
-	  file := input[target]
+	    file := input[target]
 		var content []byte
 		if file.Content != nil {
 			content = []byte(*file.Content)

--- a/internal/compose/convert.go
+++ b/internal/compose/convert.go
@@ -240,7 +240,8 @@ func convertFilesIntoVolumes(state *project.State, workloadName string, containe
 	if err = os.MkdirAll(filesDir, 0755); err != nil && !errors.Is(err, os.ErrExist) {
 		return nil, fmt.Errorf("failed to ensure the files directory exists")
 	}
-	for target, file := range input {
+	for target := range slices.Sorted(maps.Keys(input)) {
+	  file := input[target]
 		var content []byte
 		if file.Content != nil {
 			content = []byte(*file.Content)


### PR DESCRIPTION
github.com/score-spec/score-go v1.10.0

https://github.com/score-spec/score-go/pull/103 based on https://github.com/score-spec/spec/pull/123#issuecomment-2793203515

This PR also makes sure that previous/old `files|volumes` spec is still working while we support the new spec.

Both examples working with this new version:

Old `files|volumes` spec:
```yaml
apiVersion: score.dev/v1b1
metadata:
  name: hello-world
containers:
  hello:
    image: .
    files:
      - target: /fileB.txt
        content: |
          I am ${metadata.name}
    volumes:
     - target: /data
        source: ${resources.data}
resources:
  data:
    type: volume
```

New `files|volumes` spec:
```yaml
apiVersion: score.dev/v1b1
metadata:
  name: hello-world
containers:
  hello:
    image: .
    files:
      "/fileB.txt":
        content: |
          I am ${metadata.name}
    volumes:
      "/data":
        source: ${resources.data}
resources:
  data:
    type: volume
```