### PR TITLE
Unit tests: Fix `docker compose` `convert` by `config`

### DIFF
--- a/internal/command/generate_examples_test.go
+++ b/internal/command/generate_examples_test.go
@@ -289,7 +289,7 @@ services:
 			if os.Getenv("NO_DOCKER") == "" {
 				dockerCmd, err := exec.LookPath("docker")
 				require.NoError(t, err)
-				cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "convert", "--quiet", "--dry-run")
+				cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "config", "--quiet", "--dry-run")
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr
 				assert.NoError(t, cmd.Run())

--- a/internal/command/generate_test.go
+++ b/internal/command/generate_test.go
@@ -445,7 +445,7 @@ resources:
 		}
 		dockerCmd, err := exec.LookPath("docker")
 		require.NoError(t, err)
-		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "convert", "--quiet", "--dry-run")
+		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "config", "--quiet", "--dry-run")
 		cmd.Dir = td
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -498,7 +498,7 @@ resources:
 		}
 		dockerCmd, err := exec.LookPath("docker")
 		require.NoError(t, err)
-		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "convert", "--quiet", "--dry-run")
+		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "config", "--quiet", "--dry-run")
 		cmd.Dir = td
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -551,7 +551,7 @@ resources:
 		}
 		dockerCmd, err := exec.LookPath("docker")
 		require.NoError(t, err)
-		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "convert", "--quiet", "--dry-run")
+		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "config", "--quiet", "--dry-run")
 		cmd.Dir = td
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -644,7 +644,7 @@ services:
 		}
 		dockerCmd, err := exec.LookPath("docker")
 		require.NoError(t, err)
-		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "convert", "--quiet", "--dry-run")
+		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "config", "--quiet", "--dry-run")
 		cmd.Dir = td
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -876,7 +876,7 @@ services:
 		}
 		dockerCmd, err := exec.LookPath("docker")
 		require.NoError(t, err)
-		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "convert", "--quiet", "--dry-run")
+		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "config", "--quiet", "--dry-run")
 		cmd.Dir = td
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -970,7 +970,7 @@ resources:
 		}
 		dockerCmd, err := exec.LookPath("docker")
 		require.NoError(t, err)
-		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "convert", "--quiet", "--dry-run")
+		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "config", "--quiet", "--dry-run")
 		cmd.Dir = td
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -1305,7 +1305,7 @@ resources:
 		}
 		dockerCmd, err := exec.LookPath("docker")
 		require.NoError(t, err)
-		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "convert", "--quiet", "--dry-run")
+		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "config", "--quiet", "--dry-run")
 		cmd.Dir = td
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -1358,7 +1358,7 @@ resources:
 		}
 		dockerCmd, err := exec.LookPath("docker")
 		require.NoError(t, err)
-		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "convert", "--quiet", "--dry-run")
+		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "config", "--quiet", "--dry-run")
 		cmd.Dir = td
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -1436,7 +1436,7 @@ resources:
 		}
 		dockerCmd, err := exec.LookPath("docker")
 		require.NoError(t, err)
-		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "convert", "--quiet", "--dry-run")
+		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "config", "--quiet", "--dry-run")
 		cmd.Dir = td
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -1481,7 +1481,7 @@ resources:
 		}
 		dockerCmd, err := exec.LookPath("docker")
 		require.NoError(t, err)
-		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "convert", "--quiet", "--dry-run")
+		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "config", "--quiet", "--dry-run")
 		cmd.Dir = td
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -231,7 +231,7 @@ volumes:
 
 `), 0644))
 
-		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "-f", "volume.yaml", "convert", "--quiet", "--dry-run")
+		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "-f", "volume.yaml", "config", "--quiet", "--dry-run")
 		cmd.Dir = td
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -318,7 +318,7 @@ func TestRunExample01(t *testing.T) {
 		dockerCmd, err := exec.LookPath("docker")
 		require.NoError(t, err)
 
-		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "convert", "--quiet", "--dry-run")
+		cmd := exec.Command(dockerCmd, "compose", "-f", "compose.yaml", "config", "--quiet", "--dry-run")
 		cmd.Dir = td
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr

--- a/internal/compose/convert_test.go
+++ b/internal/compose/convert_test.go
@@ -633,7 +633,7 @@ func TestConvertFiles_with_mode(t *testing.T) {
 						Files: map[string]score.ContainerFile{
 							"/ant.txt": {Content: util.Ref("stuff")},
 							"/bat.txt": {Content: util.Ref("stuff"), Mode: util.Ref("0600")},
-							"/cat.txt": {Content: util.Ref("stuff"), Mode: util.Ref("0755")},
+							"/cat.txt": {Content: util.Ref("stuff"), Mode: util.Ref("0754")},
 							"/dog.txt": {Content: util.Ref("stuff"), Mode: util.Ref("0444")},
 						},
 					},
@@ -662,7 +662,7 @@ func TestConvertFiles_with_mode(t *testing.T) {
 	assert.False(t, out[1].ReadOnly)
 	st, err = os.Stat(filepath.Join(td, "files/my-workload-files-cat.txt"))
 	assert.NoError(t, err)
-	assert.Equal(t, 0755, int(st.Mode()))
+	assert.Equal(t, 0754, int(st.Mode()))
 	assert.False(t, out[2].ReadOnly)
 	st, err = os.Stat(filepath.Join(td, "files/my-workload-files-dog.txt"))
 	assert.NoError(t, err)


### PR DESCRIPTION
In unit tests, fix `docker compose` `convert` by `config`, since https://github.com/docker/compose/releases/tag/v2.36.1, as per https://github.com/docker/compose/pull/12850.

Now, to run the unit tests locally, `docker compose version` should be greater or equal to `v2.36.1` in your local machine.