### PR TITLE
fix(provisioners): wait for rabbitmq vhosts before init script

### DIFF
--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -417,6 +417,9 @@
       driver: local
   files: |
     {{ dig .Init.sk "instanceServiceName" "" .Shared }}-db-scripts/{{ .State.vhost }}.sh: |
+      while ! rabbitmqctl list_vhosts > /dev/null 2>&1; do
+        sleep 1
+      done
       rabbitmqctl list_vhosts | grep {{ .State.vhost }} || rabbitmqctl add_vhost {{ .State.vhost }}
       rabbitmqctl list_users | grep {{ .State.username }} || rabbitmqctl add_user {{ .State.username }} {{ .State.password }}
       rabbitmqctl set_user_tags {{ .State.username }} administrator


### PR DESCRIPTION
We use the RabbitMQ default provisioner regularly, and sometimes we get start up failures due to:

```
...                                                                                                                                                                 
 ✔ Container integration-tests-rabbitmq-2oSrWo-1       Healthy    
 ✘ Container integration-tests-rabbitmq-2oSrWo-init-1  service "rabbitmq-2oSrWo-init" didn't complete successfully: exit 64           
...                                                                                        
```

And looking that the logs shows

```
docker logs integration-tests-rabbitmq-2oSrWo-init-1
+ source /db-scripts/vhost-yoSrxqzL.sh
+ rabbitmqctl list_vhosts
+ grep vhost-yoSrxqzL
Error: unable to perform an operation on node 'rabbit@1d40eb897a0c'. Please see diagnostics information and suggestions below.
```

This seems to be because the port-connectivity check used in the RabbitMQ readiness probe is not deep enough to unblock this script. 