### PR TITLE
feat: improve error message clarity when no workloads are available

### DIFF
--- a/internal/command/generate.go
+++ b/internal/command/generate.go
@@ -211,7 +211,11 @@ arguments.
 		}
 
 		if len(currentState.Workloads) == 0 {
-			return fmt.Errorf("the project is empty, please provide a score file to generate from")
+			// Check if there's a score.yaml file in the current directory
+			if _, err := os.Stat("score.yaml"); err == nil {
+				return fmt.Errorf("no workloads to generate from. Did you mean to run: score-compose generate score.yaml")
+			}
+			return fmt.Errorf("no workloads to generate from. Please specify a score file, e.g., score-compose generate score.yaml")
 		}
 
 		loadedProvisioners, err := provloader.LoadProvisionersFromDirectory(sd.Path, provloader.DefaultSuffix)

--- a/internal/command/generate_test.go
+++ b/internal/command/generate_test.go
@@ -103,11 +103,31 @@ func TestGenerateWithoutInit(t *testing.T) {
 
 func TestGenerateWithoutScoreFiles(t *testing.T) {
 	_ = changeToTempDir(t)
-	stdout, _, err := executeAndResetCommand(context.Background(), rootCmd, []string{"init"})
+	stdout, _, err := executeAndResetCommand(context.Background(), rootCmd, []string{"init", "--no-sample"})
 	assert.NoError(t, err)
 	assert.Equal(t, "", stdout)
 	stdout, _, err = executeAndResetCommand(context.Background(), rootCmd, []string{"generate"})
-	assert.EqualError(t, err, "the project is empty, please provide a score file to generate from")
+	assert.EqualError(t, err, "no workloads to generate from. Please specify a score file, e.g., score-compose generate score.yaml")
+	assert.Equal(t, "", stdout)
+}
+
+func TestGenerateWithScoreYamlPresent(t *testing.T) {
+	td := changeToTempDir(t)
+	stdout, _, err := executeAndResetCommand(context.Background(), rootCmd, []string{"init"})
+	assert.NoError(t, err)
+	assert.Equal(t, "", stdout)
+
+	// Create a score.yaml file in the directory
+	assert.NoError(t, os.WriteFile(filepath.Join(td, "score.yaml"), []byte(`apiVersion: score.dev/v1b1
+metadata:
+  name: hello-world
+containers:
+  hello:
+    image: busybox
+`), 0644))
+
+	stdout, _, err = executeAndResetCommand(context.Background(), rootCmd, []string{"generate"})
+	assert.EqualError(t, err, "no workloads to generate from. Did you mean to run: score-compose generate score.yaml")
 	assert.Equal(t, "", stdout)
 }
 


### PR DESCRIPTION
## Summary

Improves the error message shown when users run `score-compose generate` without any workloads, making it clearer and more actionable.

## Changes

- **Better error messages**: Replaced the confusing "the project is empty, please provide a score file to generate from" with contextual messages
- **Smart detection**: Added logic to detect if `score.yaml` exists in the current directory
  - If `score.yaml` exists: Shows "no workloads to generate from. Did you mean to run: score-compose generate score.yaml"
  - If no `score.yaml`: Shows "no workloads to generate from. Please specify a score file, e.g., score-compose generate score.yaml"
- **Enhanced testing**: Updated and added test cases to properly handle the init command's default behavior and new error message logic

## Problem Addressed

The original error message "the project is empty, please provide a score file to generate from" was confusing because:
1. It didn't clearly indicate what the user should do next
2. It didn't suggest the most common case (using `score.yaml`)
3. Users weren't sure if they needed to create a file or specify an existing one

## Testing

- All existing tests pass
- Added new test case `TestGenerateWithScoreYamlPresent` to verify behavior when `score.yaml` is present
- Updated `TestGenerateWithoutScoreFiles` to use `--no-sample` flag to properly test the no-file scenario

Fixes #287

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>