### PR TITLE
Update Dockerfile - remove debug info from container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN go mod download
 
 # Copy the entire project and build it.
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-X github.com/score-spec/score-compose/internal/version.Version=${VERSION}" -o /usr/local/bin/score-compose ./cmd/score-compose
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X github.com/score-spec/score-compose/internal/version.Version=${VERSION}" -o /usr/local/bin/score-compose ./cmd/score-compose
 
 # We can use gcr.io/distroless/static since we don't rely on any linux libs or state, but we need ca-certificates to connect to https/oci with the init command.
 FROM gcr.io/distroless/static:530158861eebdbbf149f7e7e67bfe45eb433a35c@sha256:5c7e2b465ac6a2a4e5f4f7f722ce43b147dabe87cb21ac6c4007ae5178a1fa58


### PR DESCRIPTION
Update Dockerfile - remove debug info from container image

https://pkg.go.dev/cmd/link:
- `-s`: Omit the symbol table and debug information.
- `-w`: Omit the DWARF symbol table.

On disk, `5.7MB` saved (-26%) with the new container image:
```none
ghcr.io/score-spec/score-compose                  0.29.6       a57037879021   2 hours ago    15.9MB
ghcr.io/score-spec/score-compose                  0.29.5       4cdcfc0c8378   3 weeks ago    21.6MB
```