### PR TITLE
Update release.yaml - fix release by pinning cosign version to v2.6.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,8 @@ jobs:
           go-version-file: 'go.mod'
       - name: Install Cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+        with:
+          cosign-release: "v2.6.1"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:


### PR DESCRIPTION
Update release.yaml - fix release by pinning cosign version to v2.6.1, see reference here: https://github.com/goreleaser/goreleaser/issues/6195.

Otherwise getting this error when trying to do a release: https://github.com/score-spec/score-compose/actions/runs/18727914904/job/53417221521:
```none
 • signing artifacts
    • signing                                        cmd=cosign artifact=score-compose_0.29.6_darwin_arm64.tar.gz signature=dist/score-compose_0.29.6_darwin_arm64.tar.gz.sig certificate=dist/score-compose_0.29.6_darwin_arm64.tar.gz.pem
Error: must provide --bundle with --signing-config or --use-signing-config
error during command execution: must provide --bundle with --signing-config or --use-signing-config
  ⨯ release failed after 23s                        
    error=
    │ sign: cosign failed: exit status 1: Error: must provide --bundle with --signing-config or --use-signing-config
    │ error during command execution: must provide --bundle with --signing-config or --use-signing-config
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.12.6/x64/goreleaser' failed with exit code 1
```

For now pinning to working version v2.6.1, we'll see in the future how to use v3+, resources:
- https://github.com/sigstore/cosign-installer/releases
- https://github.com/sigstore/cosign/releases