### PR TITLE
Split CI jobs into test-code and test-container

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,16 +112,3 @@ jobs:
           docker run --rm score-compose:pr-${{ github.event.number }} --version
           docker run -v .:/score-compose --rm score-compose:pr-${{ github.event.number }} init
           cat score.yaml
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Split CI jobs into `test-code` and `test-container` and skip the `test-container` if from a fork for now.