### PR TITLE
fix: use livenessProbe fallback when readinessProbe is unset

### DIFF
--- a/internal/compose/convert.go
+++ b/internal/compose/convert.go
@@ -158,7 +158,7 @@ func ConvertSpec(state *project.State, spec *score.Workload) (*compose.Project, 
 				svc.HealthCheck = hc
 			}
 		} else if cSpec.LivenessProbe != nil {
-			if hc, err := convertProbeToExec(cSpec.ReadinessProbe); err != nil {
+			if hc, err := convertProbeToExec(cSpec.LivenessProbe); err != nil {
 				return nil, fmt.Errorf("containers.%s.livenessProbe: %w", containerName, err)
 			} else if hc != nil {
 				svc.HealthCheck = hc

--- a/internal/compose/convert_test.go
+++ b/internal/compose/convert_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	compose "github.com/compose-spec/compose-go/v2/types"
 	"github.com/score-spec/score-go/framework"
@@ -101,6 +102,41 @@ func TestScoreConvert(t *testing.T) {
 						},
 						Environment: compose.MappingWithEquals{
 							"CONNECTION_STRING": stringPtr("test connection string"),
+						},
+					},
+				},
+			},
+		},
+
+		{
+			Name: "Should use livenessProbe when readinessProbe is not set",
+			Source: &score.Workload{
+				Metadata: score.WorkloadMetadata{
+					"name": "test",
+				},
+				Containers: score.WorkloadContainers{
+					"backend": score.Container{
+						Image: "busybox",
+						LivenessProbe: &score.ContainerProbe{
+							Exec: &score.ExecProbe{Command: []string{"true"}},
+						},
+					},
+				},
+			},
+			Project: &compose.Project{
+				Services: compose.Services{
+					"test-backend": {
+						Name: "test-backend",
+						Annotations: map[string]string{
+							"compose.score.dev/workload-name": "test",
+						},
+						Hostname: "test",
+						Image:    "busybox",
+						Environment: compose.MappingWithEquals{},
+						HealthCheck: &compose.HealthCheckConfig{
+							Test:     compose.HealthCheckTest{"CMD", "true"},
+							Interval: util.Ref(compose.Duration(5 * time.Second)),
+							Timeout:  util.Ref(compose.Duration(5 * time.Second)),
 						},
 					},
 				},


### PR DESCRIPTION
Fixes #457

The liveness fallback path was still passing `readinessProbe` into `convertProbeToExec`, which can be nil in this branch and panic. This switches the fallback to `livenessProbe` and adds a focused regression test for workloads that only define a liveness probe.

Greetings, saschabuehrle