### PR TITLE
fix: use correct flag constant in --override-property error messages

### DIFF
--- a/internal/command/generate.go
+++ b/internal/command/generate.go
@@ -121,9 +121,9 @@ arguments.
 		// Now read, parse, and apply any override properties to the score files
 		if v, _ := cmd.Flags().GetStringArray(generateCmdOverridePropertyFlag); len(v) > 0 {
 			if len(workloadNames) == 0 {
-				return fmt.Errorf("--%s cannot be used without providing a score file", generateCmdOverridesFileFlag)
+				return fmt.Errorf("--%s cannot be used without providing a score file", generateCmdOverridePropertyFlag)
 			} else if len(workloadNames) > 1 {
-				return fmt.Errorf("--%s cannot be used when multiple score files are provided", generateCmdOverridesFileFlag)
+				return fmt.Errorf("--%s cannot be used when multiple score files are provided", generateCmdOverridePropertyFlag)
 			}
 			for _, overridePropertyEntry := range v {
 				if workloadSpecs[workloadNames[0]], err = parseAndApplyOverrideProperty(overridePropertyEntry, generateCmdOverridePropertyFlag, workloadSpecs[workloadNames[0]]); err != nil {


### PR DESCRIPTION
Fixes #459

#### Description
Fixed a copy-paste bug in `internal/command/generate.go` where the `--override-property` error messages were incorrectly referencing the `--overrides-file` flag.

#### What does this PR do?
The `--override-property` validation block (lines 122-127) was copy-pasted from the `--overrides-file` block above it, but the flag constant in the error messages wasn't updated. Swapped `generateCmdOverridesFileFlag` to `generateCmdOverridePropertyFlag` on lines 124 and 126 so the error now correctly says `--override-property` instead 
of `--overrides-file`.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
- [x] I've signed off with an email address that matches the commit author.
