### PR TITLE
feat: add support for importing multiple provisioners files from a local directory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/compose-spec/compose-go/v2 v2.10.2
 	github.com/go-viper/mapstructure/v2 v2.5.0
-	github.com/score-spec/score-go v1.13.0
+	github.com/score-spec/score-go v1.15.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6Ng
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
-github.com/score-spec/score-go v1.13.0 h1:m4Df2U775DaEIdmfeYXULK9iS6Cb8eSXka9QD9udJcA=
-github.com/score-spec/score-go v1.13.0/go.mod h1:3abE79XO6CEiAzZNzfnHQIm18TWrefL0ihmObCvRWO8=
+github.com/score-spec/score-go v1.15.0 h1:P8b3CfUaoR885BSvU6FhV/2/Gz7BMQqYewMRkD0O19c=
+github.com/score-spec/score-go v1.15.0/go.mod h1:3abE79XO6CEiAzZNzfnHQIm18TWrefL0ihmObCvRWO8=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -261,20 +261,18 @@ URI Retrieval:
 
 		if v, _ := cmd.Flags().GetStringArray(initCmdProvisionerFlag); len(v) > 0 {
 			for i, vi := range v {
-				data, err := uriget.GetFile(cmd.Context(), vi)
+				files, err := uriget.GetFiles(cmd.Context(), vi)
 				if err != nil {
 					return fmt.Errorf("failed to load provisioner %d: %w", i+1, err)
 				}
-
-				var saveFilename string
-				if vi == "-" {
-					saveFilename = "from-stdin.provisioners.yaml"
-				} else {
-					saveFilename = vi
-				}
-
-				if err := loader.SaveProvisionerToDirectory(sd.Path, saveFilename, data); err != nil {
-					return fmt.Errorf("failed to save provisioner %d: %w", i+1, err)
+				for _, f := range files {
+					saveFilename := f.URI
+					if saveFilename == "-" {
+						saveFilename = "from-stdin.provisioners.yaml"
+					}
+					if err := loader.SaveProvisionerToDirectory(sd.Path, saveFilename, f.Content); err != nil {
+						return fmt.Errorf("failed to save provisioner from %s: %w", f.URI, err)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
#### Description

This PR makes two changes:

1. Replace uriget.GetFile with uriget.GetFiles for the --provisioners flag in the init command. When a local directory path is passed, all files in
the directory are imported individually, sorted by name. Single file paths and remote URIs continue to work as before.

2. Rework SaveProvisionerToDirectory to drop the time-based prefix from saved provisioner filenames. Instead, the original base name from the 
source URI is preserved along with a hash suffix. This ensures that files with explicit ordering prefixes (e.g., 10-, 20-) retain their intended 
load order when read from the state directory.

Depends on: score-spec/score-go#([180](https://github.com/score-spec/score-go/pull/180)) — adds the GetFiles function to the uriget package.

**Note:** This PR currently uses a local replace directive in go.mod pointing to the score-go branch. This should be updated to the released score-go 
version before merging.

#### What does this PR do?

Relates to score-spec/score-go#177

Enables users to pass a local directory to --provisioners during score-compose init, importing all provisioner files from that directory in a 
single command. Previously, each file had to be specified individually.

**Before:**
score-compose init \
  --provisioners ./provisioners/10-service.provisioners.yaml \
  --provisioners ./provisioners/20-redis.provisioners.yaml


**After:**
score-compose init --provisioners ./provisioners/


The saved filenames now preserve the original name and ordering:
**Before: meaningless base64 names**
`f0B3kQ2x.a8Dk3mP9qR.provisioners.yaml`

**After: readable, ordered**
```
10-service.a8Dk3mP9qR.provisioners.yaml
20-redis.b7Ck2lO8pQ.provisioners.yaml
```


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:

- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.