### PR TITLE
chore: update score-go to include CPU regex fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/compose-spec/compose-go/v2 v2.10.2
 	github.com/go-viper/mapstructure/v2 v2.5.0
-	github.com/score-spec/score-go v1.15.0
+	github.com/score-spec/score-go v1.16.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
@@ -62,5 +62,3 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	oras.land/oras-go/v2 v2.6.0 // indirect
 )
-
-replace github.com/score-spec/score-go => github.com/Abhishek9639/score-go v0.0.0-20260415094058-8a2615c996fb

--- a/go.mod
+++ b/go.mod
@@ -62,3 +62,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	oras.land/oras-go/v2 v2.6.0 // indirect
 )
+
+replace github.com/score-spec/score-go => github.com/Abhishek9639/score-go v0.0.0-20260415094058-8a2615c996fb

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
+github.com/Abhishek9639/score-go v0.0.0-20260415094058-8a2615c996fb h1:qItEc+bA0qyBf/gEBb74GPb/Do62uz3N7nvEcRbfHik=
+github.com/Abhishek9639/score-go v0.0.0-20260415094058-8a2615c996fb/go.mod h1:3abE79XO6CEiAzZNzfnHQIm18TWrefL0ihmObCvRWO8=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
@@ -78,8 +80,6 @@ github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6Ng
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
-github.com/score-spec/score-go v1.15.0 h1:P8b3CfUaoR885BSvU6FhV/2/Gz7BMQqYewMRkD0O19c=
-github.com/score-spec/score-go v1.15.0/go.mod h1:3abE79XO6CEiAzZNzfnHQIm18TWrefL0ihmObCvRWO8=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
-github.com/Abhishek9639/score-go v0.0.0-20260415094058-8a2615c996fb h1:qItEc+bA0qyBf/gEBb74GPb/Do62uz3N7nvEcRbfHik=
-github.com/Abhishek9639/score-go v0.0.0-20260415094058-8a2615c996fb/go.mod h1:3abE79XO6CEiAzZNzfnHQIm18TWrefL0ihmObCvRWO8=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
@@ -80,6 +78,8 @@ github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6Ng
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+github.com/score-spec/score-go v1.16.0 h1:eAKec2ZYDJgtSVaOSYdA0Y5XHEJFFTebEQyYtoqpFKU=
+github.com/score-spec/score-go v1.16.0/go.mod h1:3abE79XO6CEiAzZNzfnHQIm18TWrefL0ihmObCvRWO8=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=


### PR DESCRIPTION
### Description
Updates the `score-go` dependency to pick up the CPU regex fix from score-spec/score-go#181. Uses a `replace` directive to point to the branch until the fix is merged upstream.

### What does this PR do?
The CPU resource limit pattern in score-go was accepting empty strings. This updates score-compose to use the fixed version where at least one digit is required. All existing tests pass with this change.

Related: score-spec/spec#188

### Types of changes
- [x] New chore (expected functionality to be implemented)

### Checklist:
- [x] I've signed off with an email address that matches the commit author.
