### PR TITLE
init: update the default sample Score file generated

### DIFF
--- a/internal/command/generate_test.go
+++ b/internal/command/generate_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/score-spec/score-go/framework"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -143,46 +144,29 @@ func TestInitAndGenerate_with_sample(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "", stdout)
 
-	// write overrides file
-	assert.NoError(t, os.WriteFile(filepath.Join(td, "overrides.yaml"), []byte(`{"resources": {"foo": {"type": "environment"}}}`), 0644))
-	// generate
+	// Resources use randomized service names in compose output, so check state instead.
 	stdout, _, err = executeAndResetCommand(context.Background(), rootCmd, []string{
-		"generate", "-o", "compose-output.yaml",
-		"--overrides-file", "overrides.yaml",
-		"--override-property", "containers.hello-world.variables.THING=${resources.foo.THING}",
-		"--", "score.yaml",
+		"generate", "--", "score.yaml",
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "", stdout)
-	raw, err := os.ReadFile(filepath.Join(td, "compose-output.yaml"))
+
+	// check that state was persisted with the correct workload and resource structure
+	sd, ok, err := project.LoadStateDirectory(td)
 	assert.NoError(t, err)
-	expectedOutput := `name: "001"
-services:
-  example-hello-world:
-    annotations:
-      compose.score.dev/workload-name: example
-    environment:
-      EXAMPLE_VARIABLE: example-value
-      THING: ${THING}
-    hostname: example
-    image: nginx:latest
-`
-	assert.Equal(t, expectedOutput, string(raw))
+	assert.True(t, ok)
+	assert.Contains(t, sd.State.Workloads, "hello-world")
+	assert.Equal(t, "score.yaml", *sd.State.Workloads["hello-world"].File)
+	assert.Len(t, sd.State.Workloads, 1)
+	assert.Len(t, sd.State.Resources, 3)
+	assert.Contains(t, sd.State.Resources, framework.ResourceUid("postgres.default#hello-world.db"))
+	assert.Contains(t, sd.State.Resources, framework.ResourceUid("dns.default#hello-world.dns"))
+	assert.Contains(t, sd.State.Resources, framework.ResourceUid("route.default#hello-world.route"))
+
 	// generate again just for luck
 	stdout, _, err = executeAndResetCommand(context.Background(), rootCmd, []string{"generate", "-o", "compose-output.yaml"})
 	assert.NoError(t, err)
 	assert.Equal(t, "", stdout)
-	raw, err = os.ReadFile(filepath.Join(td, "compose-output.yaml"))
-	assert.NoError(t, err)
-	assert.Equal(t, expectedOutput, string(raw))
-
-	// check that state was persisted
-	sd, ok, err := project.LoadStateDirectory(td)
-	assert.NoError(t, err)
-	assert.True(t, ok)
-	assert.Equal(t, "score.yaml", *sd.State.Workloads["example"].File)
-	assert.Len(t, sd.State.Workloads, 1)
-	assert.Len(t, sd.State.Resources, 1)
 }
 
 func TestInitAndGenerate_with_image_override(t *testing.T) {

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -33,41 +33,44 @@ import (
 )
 
 const (
-	DefaultScoreFileContent = `# Score provides a developer-centric and platform-agnostic 
-# Workload specification to improve developer productivity and experience. 
+	DefaultScoreFileContent = `# Score provides a developer-centric and platform-agnostic
+# Workload specification to improve developer productivity and experience.
 # Score eliminates configuration management between local and remote environments.
 #
-# Specification reference: https://docs.score.dev/docs/reference/score-spec-reference/
+# Get started with Score: https://docs.score.dev/docs/get-started/.
 ---
-
-# Score specification version
 apiVersion: score.dev/v1b1
-
 metadata:
-  name: example
-
+  name: hello-world
+  annotations:
+    tags: "nodejs,http,website,javascript,postgres"
 containers:
   hello-world:
-    image: nginx:latest
-
-    # Uncomment the following for a custom entrypoint command
-    # command: []
-
-    # Uncomment the following for custom arguments
-    # args: []
-
-    # Environment variables to inject into the container
+    image: scorespec/sample-score-app:latest
     variables:
-      EXAMPLE_VARIABLE: "example-value"
-
+      PORT: "3000"
+      MESSAGE: "Hello, World!"
+      DB_DATABASE: ${resources.db.name}
+      DB_USER: ${resources.db.username}
+      DB_PASSWORD: ${resources.db.password}
+      DB_HOST: ${resources.db.host}
+      DB_PORT: ${resources.db.port}
+resources:
+  db:
+    type: postgres
+  dns:
+    type: dns
+  route:
+    type: route
+    params:
+      host: ${resources.dns.host}
+      path: /
+      port: 8080
 service:
   ports:
-    # Expose the http port from nginx on port 8080
     www:
       port: 8080
-      targetPort: 80
-
-resources: {}
+      targetPort: 3000
 `
 	scoreFileDefault                 = "./score.yaml"
 	initCmdFileFlag                  = "file"

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -120,18 +120,9 @@ func TestInitNominal(t *testing.T) {
 	assert.Equal(t, "", stdout)
 	assert.NotEqual(t, "", strings.TrimSpace(stderr))
 
-	stdout, stderr, err = executeAndResetCommand(context.Background(), rootCmd, []string{"generate", "score.yaml", "--output", "-"})
+	// Resources use randomized service names in compose output, so check state instead.
+	_, stderr, err = executeAndResetCommand(context.Background(), rootCmd, []string{"generate", "score.yaml"})
 	assert.NoError(t, err)
-	assert.Equal(t, `name: "001"
-services:
-  example-hello-world:
-    annotations:
-      compose.score.dev/workload-name: example
-    environment:
-      EXAMPLE_VARIABLE: example-value
-    hostname: example
-    image: nginx:latest
-`, stdout)
 	assert.NotEqual(t, "", strings.TrimSpace(stderr))
 
 	sd, ok, err := project.LoadStateDirectory(".")
@@ -140,9 +131,12 @@ services:
 		assert.Equal(t, project.DefaultRelativeStateDirectory, sd.Path)
 		assert.Equal(t, filepath.Base(td), sd.State.Extras.ComposeProjectName)
 		assert.Equal(t, filepath.Join(project.DefaultRelativeStateDirectory, "mounts"), sd.State.Extras.MountsDirectory)
-		assert.Equal(t, 1, len(sd.State.Workloads))
-		assert.Equal(t, map[framework.ResourceUid]framework.ScoreResourceState[framework.NoExtras]{}, sd.State.Resources)
-		assert.Equal(t, map[string]interface{}{}, sd.State.SharedState)
+		assert.Len(t, sd.State.Workloads, 1)
+		assert.Contains(t, sd.State.Workloads, "hello-world")
+		assert.Len(t, sd.State.Resources, 3)
+		assert.Contains(t, sd.State.Resources, framework.ResourceUid("postgres.default#hello-world.db"))
+		assert.Contains(t, sd.State.Resources, framework.ResourceUid("dns.default#hello-world.dns"))
+		assert.Contains(t, sd.State.Resources, framework.ResourceUid("route.default#hello-world.route"))
 	}
 }
 


### PR DESCRIPTION
#### Description
The default `score.yaml` generated by `score-compose init` used a basic nginx example that didn't really show what Score is capable of. This PR replaces it with a more meaningful sample that demonstrates resource provisioning, environment variable substitution, and routing things that actually help a new user understand why Score is useful.

#### What does this PR do?
Closes #475

Updates `DefaultScoreFileContent` in `internal/command/init.go` to generate a richer sample `score.yaml` that:
- Uses `scorespec/sample-score-app:latest` instead of nginx
- Provisions a **postgres** database resource and injects its connection details as environment variables (`DB_HOST`, `DB_PORT`, `DB_DATABASE`, etc.)
- Provisions a **dns** resource and a **route** resource for HTTP routing
- Points to the Getting Started guide: https://docs.score.dev/docs/get-started/

All three resource types (`postgres`, `dns`, `route`) are included in the default provisioners, so `score-compose generate` works out of the box with no extra setup needed.

Also updated `TestInitNominal` and `TestInitAndGenerate_with_sample` to reflect the new sample structure.

#### Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [x] My change requires a change to the documentation.
- [x] I've signed off with an email address that matches the commit author.
