### PR TITLE
Add Scoop and WinGet support for Windows

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,6 +43,50 @@ brews:
     commit_author:
       name: rachfop
       email: prachford@icloud.com
+scoops:
+  - name: score-compose
+    homepage: "https://score.dev"
+    description: "score-compose is a reference implementation of the Score specification for Docker compose, primarily used for local development."
+    license: Apache-2.0
+    skip_upload: auto
+    commit_msg_template: "Scoop update for {{ .ProjectName }} version {{ .Tag }}"
+    commit_author:
+      name: rachfop
+      email: prachford@icloud.com
+    repository:
+      owner: score-spec
+      name: scoop-bucket
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+winget:
+  - name: score-compose
+    publisher: score-spec
+    short_description: "Reference Score implementation for Docker compose."
+    license: "Apache-2.0"
+    license_url: "https://github.com/score-spec/score-compose/blob/main/LICENSE"
+    publisher_url: "https://score.dev"
+    publisher_support_url: "https://github.com/score-spec/score-compose/issues"
+    package_identifier: score-spec.score-compose
+    homepage: "https://score.dev"
+    skip_upload: auto
+    release_notes_url: "https://github.com/score-spec/score-compose/releases/tag/{{ .Tag }}"
+    tags:
+      - score
+      - docker-compose
+      - devops
+      - cli
+    commit_author:
+      name: rachfop
+      email: prachford@icloud.com
+    repository:
+      owner: score-spec
+      name: winget-pkgs
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+      pull_request:
+        enabled: true
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: master
 signs:
   - cmd: cosign
     signature: "${artifact}.sigstore.json"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,28 @@ These can be found in the default provisioners file. You are encouraged to write
 
 ## Installation
 
+### macOS / Linux
+
 To install `score-compose`, follow the instructions as described in our [installation guide](https://docs.score.dev/docs/score-implementation/score-compose/#installation). You will also need a recent version of Docker and the Compose plugin installed. Read more [here](https://docs.docker.com/compose/install/).
+
+### Windows
+
+**[Scoop](https://scoop.sh/) (recommended):**
+
+```powershell
+scoop bucket add score-spec https://github.com/score-spec/scoop-bucket
+scoop install score-compose
+```
+
+**[WinGet](https://learn.microsoft.com/en-us/windows/package-manager/winget/) (Windows 10/11 built-in):**
+
+```powershell
+winget install score-spec.score-compose
+```
+
+**Manual:**
+
+Download the latest Windows `.zip` from the [GitHub Releases page](https://github.com/score-spec/score-compose/releases) and add `score-compose.exe` to your `PATH`.
 
 ## Get started
 


### PR DESCRIPTION
Add Scoop and WinGet support for Windows (#147)

#### Description
This adds Windows package manager support to `score-compose` so that Windows users can install the CLI without manually downloading and extracting a zip file.

Two package managers are now supported via GoReleaser automation:
- **Scoop** - publishes a manifest to `score-spec/scoop-bucket` on every release using the existing `TAP_GITHUB_TOKEN` secret (same token already used for Homebrew, so no new secrets are needed).
- **WinGet** - generates manifests and opens a pull request to `microsoft/winget-pkgs` via `score-spec/winget-pkgs` fork on every release.

The `README.md` installation section has also been updated to document all three Windows install methods: Scoop, WinGet, and manual download.

#### What does this PR do?
Closes #147

Windows users currently have no package manager option for `score-compose` they have to go to the Releases page, download a zip, extract it, and manually add the binary to their PATH. This PR wires up GoReleaser to handle Scoop and WinGet publishing automatically on every release, bringing the Windows experience on par with macOS (Homebrew).

> **Note for maintainers:** Two one-time org-level steps are needed
> before the automation triggers on the next release:
> 1. Create the `score-spec/scoop-bucket` repository.
> 2. Fork `microsoft/winget-pkgs` into the `score-spec` org.

#### Types of changes
- [x] New feature (non-breaking change which adds functionality)

#### Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.
