### PR TITLE
fix: sandbox containers[].files[].source to the Score file's directory

### DIFF
--- a/internal/compose/convert.go
+++ b/internal/compose/convert.go
@@ -312,7 +312,10 @@ func convertFilesIntoVolumes(state *project.State, workloadName string, containe
 			content = []byte(*file.Content)
 		} else if file.Source != nil {
 			sourcePath := *file.Source
-			if !filepath.IsAbs(sourcePath) && state.Workloads[workloadName].File != nil {
+			if !filepath.IsLocal(sourcePath) {
+				return nil, fmt.Errorf("containers.%s.files[%s].source: must be a relative path within the Score file's directory", containerName, target)
+			}
+			if state.Workloads[workloadName].File != nil {
 				sourcePath = filepath.Join(filepath.Dir(*state.Workloads[workloadName].File), sourcePath)
 			}
 			content, err = os.ReadFile(sourcePath)

--- a/internal/compose/convert_test.go
+++ b/internal/compose/convert_test.go
@@ -782,7 +782,7 @@ func TestConvertFilesIntoVolumes_file_missing(t *testing.T) {
 				Containers: map[string]score.Container{
 					"my-container": {
 						Files: map[string]score.ContainerFile{
-							"/ant.txt": {Source: util.Ref(filepath.Join(td, "original.txt"))},
+							"/ant.txt": {Source: util.Ref("original.txt")},
 						},
 					},
 				},
@@ -800,6 +800,42 @@ func TestConvertFilesIntoVolumes_file_missing(t *testing.T) {
 		},
 	)
 	assert.EqualError(t, err, fmt.Sprintf("containers.my-container.files[/ant.txt].source: failed to read: open %s/original.txt: no such file or directory", td))
+}
+
+func TestConvertFilesIntoVolumes_source_outside_score_dir(t *testing.T) {
+	td := t.TempDir()
+	for name, source := range map[string]string{
+		"absolute path": filepath.Join(td, "leak.txt"),
+		"parent escape": "../leak.txt",
+		"nested escape": "subdir/../../leak.txt",
+	} {
+		t.Run(name, func(t *testing.T) {
+			state := &project.State{
+				Workloads: map[string]framework.ScoreWorkloadState[project.WorkloadExtras]{"my-workload": {
+					Spec: score.Workload{
+						Containers: map[string]score.Container{
+							"my-container": {
+								Files: map[string]score.ContainerFile{
+									"/ant.txt": {Source: util.Ref(source)},
+								},
+							},
+						},
+					},
+					File: util.Ref(filepath.Join(td, "score.yaml")),
+				}},
+				Extras: project.StateExtras{
+					MountsDirectory: td,
+				},
+			}
+			_, err := convertFilesIntoVolumes(
+				state, "my-workload", "my-container",
+				func(s string) (string, error) {
+					return "", fmt.Errorf("unknown key")
+				},
+			)
+			assert.EqualError(t, err, "containers.my-container.files[/ant.txt].source: must be a relative path within the Score file's directory")
+		})
+	}
 }
 
 func TestConvertFilesIntoVolumes_source_missing(t *testing.T) {


### PR DESCRIPTION
Closes #495.

## What this does

Rejects `containers[].files[].source` paths that resolve outside the Score file's directory by applying `filepath.IsLocal` to the user-supplied source the same primitive already used in `internal/provisioners/core.go` for provisioner-generated `RelativeDirectories`. The check runs before the directory join, so both absolute paths and `..` escapes are caught regardless of whether the workload's `File` is set.

## What changed

- `internal/compose/convert.go`: `IsLocal` check before the existing join
- `internal/compose/convert_test.go`:
  - New `TestConvertFilesIntoVolumes_source_outside_score_dir` covers absolute paths, parent escapes, and nested escapes
  - `TestConvertFilesIntoVolumes_file_missing` updated to use a relative path (still asserts the "missing file" error, just within the Score file's directory)

## Behavior change

Score files that previously passed an **absolute** `containers[].files[].source` will now be rejected. Migration: switch to the equivalent relative path.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/compose/` clean
- [x] `go test ./internal/compose/`  new test and surrounding tests pass
- [ ] CI green on Linux
