### PR TITLE
refactor: migrate Kafka provisioner from bitnami/kafka to apache/kafka and update configuration parameters

### DIFF
--- a/internal/command/default.provisioners.yaml
+++ b/internal/command/default.provisioners.yaml
@@ -752,16 +752,20 @@
     shared_kafka_instance_name: {{ dig "shared_kafka_instance_name" (print "kafka-" (randAlphaNum 6)) .Shared | quote }}
   services: |
     {{ .Shared.shared_kafka_instance_name }}:
-      image: bitnami/kafka:latest
+      image: apache/kafka:latest
       restart: always
       environment:
-        KAFKA_CFG_NODE_ID: "0"
-        KAFKA_CFG_PROCESS_ROLES: controller,broker
-        KAFKA_CFG_LISTENERS: "PLAINTEXT://:{{ .Init.brokerPort }},CONTROLLER://:{{ .Init.ctrlPort }}"
-        KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
-        KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "0@{{ .Shared.shared_kafka_instance_name }}:{{ .Init.ctrlPort }}"
-        KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
-        KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: "false"
+        KAFKA_NODE_ID: "1"
+        KAFKA_PROCESS_ROLES: broker,controller
+        KAFKA_LISTENERS: "PLAINTEXT://:{{ .Init.brokerPort }},CONTROLLER://:{{ .Init.ctrlPort }}"
+        KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+        KAFKA_CONTROLLER_QUORUM_VOTERS: "1@{{ .Shared.shared_kafka_instance_name }}:{{ .Init.ctrlPort }}"
+        KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+        KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+        KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+        KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: "1"
+        KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: "1"
+        KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: "0"
       healthcheck:
         test: ["CMD", "kafka-topics.sh", "--list", "--bootstrap-server=localhost:{{ .Init.brokerPort }}"]
         interval: 2s
@@ -776,11 +780,11 @@
       volumes:
       - type: volume
         source: {{ .Shared.shared_kafka_instance_name }}-data
-        target: /bitnami/kafka
+        target: /var/lib/kafka/data
     {{ .State.topic }}-init:
-      image: bitnami/kafka:latest
+      image: apache/kafka:latest
       entrypoint: ["/bin/sh"]
-      command: ["-c", "kafka-topics.sh --topic={{.State.topic}} --bootstrap-server=localhost:{{ .Init.brokerPort }} --describe || kafka-topics.sh --topic={{.State.topic}} --bootstrap-server=localhost:{{ .Init.brokerPort }} --create --partitions=3"]
+      command: ["-c", "kafka-topics.sh --topic={{.State.topic}} --bootstrap-server=localhost:{{ .Init.brokerPort }} --describe || kafka-topics.sh --topic={{.State.topic}} --bootstrap-server=localhost:{{ .Init.brokerPort }} --create --partitions=3 --replication-factor=1"]
       network_mode: "service:{{ .Shared.shared_kafka_instance_name }}"
       labels:
         dev.score.compose.labels.is-init-container: "true"


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR updates the default `kafka-topic` provisioner in `internal/command/default.provisioners.yaml` to replace the deprecated Bitnami Kafka image with the official `apache/kafka:latest` image. 

#### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Bitnami Kafka image has been deprecated, requiring a migration to the official Apache Kafka container image to ensure future compatibility, security updates, and continued support. This PR seamlessly updates the compose provisioner to use the correct modern configurations (like KRaft mode) required by the official Apache image, keeping `score-compose` up to date. This is discussed over here: https://github.com/score-spec/score-k8s/pull/314#discussion_r3440532613



#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] New chore (expected functionality to be implemented)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] I've signed off with an email address that matches the commit author.
