### PR TITLE
feat: Support placeholder substitution in container image

### DIFF
--- a/internal/compose/convert.go
+++ b/internal/compose/convert.go
@@ -95,6 +95,11 @@ func ConvertSpec(state *project.State, spec *score.Workload) (*compose.Project, 
 	for _, containerName := range containerNames {
 		cSpec := spec.Containers[containerName]
 
+		// cSpec is a copy of the map entry, so resolving in-place here is safe.
+		if cSpec.Image, err = variablesSubstitutor.SubstituteString(cSpec.Image); err != nil {
+			return nil, fmt.Errorf("containers.%s.image: %w", containerName, err)
+		}
+
 		var env = make(compose.MappingWithEquals, len(cSpec.Variables))
 		for key, val := range cSpec.Variables {
 			resolved, err := variablesSubstitutor.SubstituteString(val)

--- a/internal/compose/convert_test.go
+++ b/internal/compose/convert_test.go
@@ -940,3 +940,95 @@ func TestConvertFiles_with_mode(t *testing.T) {
 	assert.Equal(t, 0644, int(st.Mode()))
 	assert.True(t, out[3].ReadOnly)
 }
+
+func TestConvertSpec_image_placeholders(t *testing.T) {
+	buildWorkload := func(image string) *score.Workload {
+		return &score.Workload{
+			Metadata: score.WorkloadMetadata{
+				"name": "test",
+				"annotations": map[string]interface{}{
+					"devbox.io/revision": "abc123",
+				},
+			},
+			Containers: score.WorkloadContainers{
+				"backend": score.Container{Image: image},
+			},
+			Resources: score.WorkloadResources{
+				"img": score.Resource{Type: "image-ref"},
+				"env": score.Resource{Type: "environment"},
+			},
+		}
+	}
+
+	for _, tt := range []struct {
+		Name     string
+		Image    string
+		Expected string
+		Error    string
+	}{
+		{Name: "no placeholder", Image: "busybox", Expected: "busybox"},
+		{
+			Name:     "metadata ref",
+			Image:    "registry.example.com/${metadata.name}:latest",
+			Expected: "registry.example.com/test:latest",
+		},
+		{
+			Name:     "annotation ref",
+			Image:    `registry.example.com/${metadata.name}:${metadata.annotations.devbox\.io/revision}`,
+			Expected: "registry.example.com/test:abc123",
+		},
+		{
+			Name:     "resource output ref",
+			Image:    "${resources.img.image}",
+			Expected: "registry.example.com/ledger:deadbeef",
+		},
+		{
+			// Deferred to compose, which interpolates the image field at "compose up" time.
+			Name:     "deferred environment ref",
+			Image:    "registry.example.com/thing:${resources.env.TAG}",
+			Expected: "registry.example.com/thing:${TAG}",
+		},
+		{
+			// $$ is left intact so that compose unescapes it into a literal $.
+			Name:     "escaped dollar left for compose",
+			Image:    "registry.example.com/thing:$${TAG}",
+			Expected: "registry.example.com/thing:$${TAG}",
+		},
+		{
+			Name:  "unknown resource",
+			Image: "${resources.nope.image}",
+			Error: "containers.backend.image: invalid ref 'resources.nope.image': no known resource 'nope'",
+		},
+		{
+			Name:  "unknown reference root",
+			Image: "registry.example.com/thing:${TAG}",
+			Error: "containers.backend.image: invalid ref 'TAG': unknown reference root, use $$ to escape the substitution",
+		},
+	} {
+		t.Run(tt.Name, func(t *testing.T) {
+			workload := buildWorkload(tt.Image)
+			state := &project.State{
+				Workloads: map[string]framework.ScoreWorkloadState[project.WorkloadExtras]{},
+				Resources: map[framework.ResourceUid]framework.ScoreResourceState[framework.NoExtras]{},
+			}
+			state, _ = state.WithWorkload(workload, nil, project.WorkloadExtras{})
+			state, _ = state.WithPrimedResources()
+			state.Resources["image-ref.default#test.img"] = framework.ScoreResourceState[framework.NoExtras]{
+				Outputs: map[string]interface{}{"image": "registry.example.com/ledger:deadbeef"},
+			}
+			evt := new(envprov.Provisioner)
+			state.Resources["environment.default#test.env"] = framework.ScoreResourceState[framework.NoExtras]{
+				OutputLookupFunc: evt.LookupOutput,
+			}
+
+			proj, err := ConvertSpec(state, workload)
+			if tt.Error != "" {
+				assert.ErrorContains(t, err, tt.Error)
+				return
+			}
+			if assert.NoError(t, err) {
+				assert.Equal(t, tt.Expected, proj.Services["test-backend"].Image)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Placeholders already resolve in `containers.*.variables`, `containers.*.files`,
  `containers.*.volumes.source` and `resources.*.params`, but
  `containers.*.image` was passed through verbatim. This resolves the image with
  the same substituter already used for variables, so it sees exactly the same
  refs:

#### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It makes the image field composable from resource outputs and workload
 metadata, instead of requiring the caller to rewrite the score file or pass
 --image. --image takes a single value per invocation, so it can't serve
 multiple workloads generated together, and it only applies to image: ".".

 The omission looks incidental rather than deliberate: the substitution
 machinery is generic, resources are fully provisioned before conversion so
 outputs are already available, and no test asserted that a placeholder in
 image stays literal.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've signed off with an email address that matches the commit author.

Related: https://github.com/score-spec/score-k8s/pull/350